### PR TITLE
Remove Spring Boot example code.

### DIFF
--- a/src/main/java/hello/Application.java
+++ b/src/main/java/hello/Application.java
@@ -17,17 +17,7 @@ public class Application {
 
     @Bean
     public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
-        return args -> {
-
-            System.out.println("Let's inspect the beans provided by Spring Boot:");
-
-            String[] beanNames = ctx.getBeanDefinitionNames();
-            Arrays.sort(beanNames);
-            for (String beanName : beanNames) {
-                System.out.println(beanName);
-            }
-
-        };
+        return args -> {};
     }
 
 }


### PR DESCRIPTION
The code from the Spring Boot example produces unnecessary console output on startup, so remove it.