### PR TITLE
Update gitignore with IntelliJ workaround.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+gradle/wrapper/gradle-wrapper.properties
 
 # Compiled class file
 *.class


### PR DESCRIPTION
Makes using IntelliJ less annoying as it keeps touching `gradle-wrapper.properties` all the time.