### PR TITLE
Initial implementation of TMC sandbox submission tracking.

### DIFF
--- a/src/main/java/pingis/config/SecurityConfig.java
+++ b/src/main/java/pingis/config/SecurityConfig.java
@@ -1,13 +1,21 @@
 package pingis.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        // The TMC sandbox POSTs its results here and doesn't support authentication, so
+        // skip authorization checks etc. for /submission-result.
+        web.ignoring().antMatchers(HttpMethod.POST, "/submission-result");
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/src/main/java/pingis/controllers/TmcSubmissionController.java
+++ b/src/main/java/pingis/controllers/TmcSubmissionController.java
@@ -1,0 +1,60 @@
+package pingis.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import pingis.entities.TmcSubmission;
+import pingis.entities.TmcSubmissionStatus;
+import pingis.repositories.TmcSubmissionRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Controller
+public class TmcSubmissionController {
+    @Autowired
+    private TmcSubmissionRepository submissionRepository;
+
+    // These request parameters are specified separately because there doesn't seem to
+    // be a simple way to rename fields when doing data binding.
+    @PostMapping("/submission-result")
+    public ResponseEntity submissionResult(
+            @RequestParam("test_output") String testOutput,
+            @RequestParam String stdout,
+            @RequestParam String stderr,
+            @RequestParam String validations,
+            @RequestParam("vm_log") String vmLog,
+            @RequestParam String token,
+            @RequestParam String status,
+            @RequestParam("exit_code") String exitCode) {
+        UUID submissionId = UUID.fromString(token);
+        TmcSubmission submission = submissionRepository.findOne(submissionId);
+
+        if (submission == null) {
+            return new ResponseEntity(HttpStatus.NOT_FOUND);
+        }
+
+        if (submission.getStatus() != TmcSubmissionStatus.PENDING) {
+            // Result is being submitted twice.
+            // TODO: decide on a better response code for this...
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+
+        int exitCodeValue = Integer.parseInt(exitCode.trim());
+
+        submission.setExitCode(exitCodeValue);
+        submission.setStatus(status);
+        submission.setStderr(stderr);
+        submission.setStdout(stdout);
+        submission.setTestOutput(testOutput);
+        submission.setValidations(validations);
+        submission.setVmLog(vmLog);
+
+        submissionRepository.save(submission);
+
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/src/main/java/pingis/entities/TmcSubmission.java
+++ b/src/main/java/pingis/entities/TmcSubmission.java
@@ -1,0 +1,93 @@
+package pingis.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.UUID;
+
+/**
+ * Created by dwarfcrank on 7/28/17.
+ */
+@Entity
+public class TmcSubmission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private Integer exitCode;
+    private String stderr;
+    private String stdout;
+    private TmcSubmissionStatus status;
+    private String testOutput;
+    private String validations;
+    private String vmLog;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Integer getExitCode() {
+        return exitCode;
+    }
+
+    public void setExitCode(Integer exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    public String getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(String stderr) {
+        this.stderr = stderr;
+    }
+
+    public String getStdout() {
+        return stdout;
+    }
+
+    public void setStdout(String stdout) {
+        this.stdout = stdout;
+    }
+
+    public TmcSubmissionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = TmcSubmissionStatus.valueOf(status.toUpperCase());
+    }
+
+    public void setStatus(TmcSubmissionStatus status) {
+        this.status = status;
+    }
+
+    public String getTestOutput() {
+        return testOutput;
+    }
+
+    public void setTestOutput(String testOutput) {
+        this.testOutput = testOutput;
+    }
+
+    public String getValidations() {
+        return validations;
+    }
+
+    public void setValidations(String validations) {
+        this.validations = validations;
+    }
+
+    public String getVmLog() {
+        return vmLog;
+    }
+
+    public void setVmLog(String vmLog) {
+        this.vmLog = vmLog;
+    }
+}

--- a/src/main/java/pingis/entities/TmcSubmissionStatus.java
+++ b/src/main/java/pingis/entities/TmcSubmissionStatus.java
@@ -1,0 +1,11 @@
+package pingis.entities;
+
+public enum TmcSubmissionStatus {
+    // Initial state, when the submission has been created.
+    // Not actually used by the sandbox.
+    PENDING,
+
+    FINISHED,
+    TIMEOUT,
+    FAILED
+}

--- a/src/main/java/pingis/repositories/TmcSubmissionRepository.java
+++ b/src/main/java/pingis/repositories/TmcSubmissionRepository.java
@@ -1,0 +1,12 @@
+package pingis.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import pingis.entities.TmcSubmission;
+
+import java.util.UUID;
+
+/**
+ * Created by dwarfcrank on 7/28/17.
+ */
+public interface TmcSubmissionRepository extends CrudRepository<TmcSubmission, UUID> {
+}

--- a/src/test/java/pingis/controllers/TmcSubmissionControllerTest.java
+++ b/src/test/java/pingis/controllers/TmcSubmissionControllerTest.java
@@ -1,0 +1,127 @@
+package pingis.controllers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.context.WebApplicationContext;
+import pingis.config.SecurityConfig;
+import pingis.entities.TmcSubmission;
+import pingis.entities.TmcSubmissionStatus;
+import pingis.repositories.TmcSubmissionRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Created by dwarfcrank on 7/28/17.
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TmcSubmissionController.class, SecurityConfig.class})
+@WebAppConfiguration
+@WebMvcTest(TmcSubmissionController.class)
+public class TmcSubmissionControllerTest {
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private TmcSubmissionRepository submissionRepository;
+
+    // TODO: Make this generate random data. This is a separate method just to please checkstyle.
+    private ResultActions performMockRequest(UUID submissionId) throws Exception {
+        return mvc.perform(
+                post("/submission-result")
+                        .param("test_output", "test_output")
+                        .param("stdout", "test_stdout")
+                        .param("stderr", "test_stderr")
+                        .param("validations", "test_validations")
+                        .param("vm_log", "test_vm_log")
+                        .param("token", submissionId.toString())
+                        .param("status", "finished")
+                        .param("exit_code", "0"));
+    }
+
+    @Test
+    public void doubleSubmitReturnsBadRequest() throws Exception {
+        UUID submissionId = UUID.randomUUID();
+        TmcSubmission submission = new TmcSubmission();
+
+        submission.setStatus(TmcSubmissionStatus.PENDING);
+        submission.setId(submissionId);
+
+        given(submissionRepository.findOne(submissionId))
+                .willReturn(submission);
+
+        performMockRequest(submissionId)
+                .andExpect(status().isOk());
+
+        performMockRequest(submissionId)
+                .andExpect(status().isBadRequest());
+
+        ArgumentCaptor<TmcSubmission> submissionCaptor = ArgumentCaptor.forClass(TmcSubmission.class);
+        verify(submissionRepository, times(2)).findOne(submissionId);
+        verify(submissionRepository, times(1)).save(submissionCaptor.capture());
+        verifyNoMoreInteractions(submissionRepository);
+    }
+
+    @Test
+    public void returnsNotFoundWithInvalidToken() throws Exception {
+        UUID submissionId = UUID.randomUUID();
+
+        given(submissionRepository.findOne(submissionId))
+                .willReturn(null);
+
+        performMockRequest(submissionId)
+                .andExpect(status().isNotFound());
+
+        verify(submissionRepository, times(1)).findOne(submissionId);
+        verifyNoMoreInteractions(submissionRepository);
+    }
+
+    @Test
+    public void testWithValidToken() throws Exception {
+        UUID submissionId = UUID.randomUUID();
+        TmcSubmission submission = new TmcSubmission();
+
+        submission.setStatus(TmcSubmissionStatus.PENDING);
+        submission.setId(submissionId);
+
+        given(submissionRepository.findOne(submissionId))
+                .willReturn(submission);
+
+        performMockRequest(submissionId)
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<TmcSubmission> submissionCaptor = ArgumentCaptor.forClass(TmcSubmission.class);
+        verify(submissionRepository, times(1)).findOne(submissionId);
+        verify(submissionRepository, times(1)).save(submissionCaptor.capture());
+        verifyNoMoreInteractions(submissionRepository);
+
+        TmcSubmission captured = submissionCaptor.getValue();
+
+        assertEquals((int)captured.getExitCode(), 0);
+        assertEquals(captured.getTestOutput(), "test_output");
+        assertEquals(captured.getStdout(), "test_stdout");
+        assertEquals(captured.getStderr(), "test_stderr");
+        assertEquals(captured.getValidations(), "test_validations");
+        assertEquals(captured.getVmLog(), "test_vm_log");
+        assertEquals(captured.getStatus(), TmcSubmissionStatus.FINISHED);
+        assertEquals(captured.getId(), submissionId);
+
+    }
+}


### PR DESCRIPTION
* Ignore `/submission-result` in SecurityConfig
* Add TmcSubmission and TmcSubmissionRepository
* Implement a controller for `/submission-result`