### PR TITLE
Separated the unit and cucumber tests to their own tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,14 +122,12 @@ test {
 task unitTest (type: Test) {
     systemProperty "spring.profiles.active", "dev"
 
-    useJUnit()
     exclude '**/cucumber/**'
 }
 
 task cucumberTest (type: Test) {
     systemProperty "spring.profiles.active", "dev"
 
-    useJUnit()
     include '**/cucumber/**'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,30 @@ bootRun {
     }
 }
 
+
+// Separates the Unit and Cucumber tests to separate tasks
+test {
+    exclude '**'
+}
+
+task unitTest (type: Test) {
+    systemProperty "spring.profiles.active", "dev"
+
+    useJUnit()
+    exclude '**/cucumber/**'
+}
+
+task cucumberTest (type: Test) {
+    systemProperty "spring.profiles.active", "dev"
+
+    useJUnit()
+    include '**/cucumber/**'
+}
+
+test.dependsOn cucumberTest, unitTest
+cucumberTest.mustRunAfter unitTest
+
+
 //Full debug prints for Travis, custom report prints for local
 if(System.env.travis == 'true') {
   test.testLogging.showStandardStreams = true

--- a/gradle/helpers/test-printing.gradle
+++ b/gradle/helpers/test-printing.gradle
@@ -1,45 +1,36 @@
 // Functions for test printing
-test { testLogging { afterSuite { desc, result -> printTestResults(desc,result) } } }
+unitTest { testLogging { afterSuite { desc, result -> printTestResults(desc,result,'UNIT') } } }
+cucumberTest { testLogging { afterSuite { desc, result -> printTestResults(desc,result,'CUKE') } } }
 
-// = [SUCCESS, FAILURE, SKIPPED]
-def unitResults = [0,0,0]
-def cucumberResults = [0,0,0]
-
-ext.printTestResults = { desc, result -> 
+ext.printTestResults = { desc, result, type -> 
   if(!desc.parent) {
-    println formatResults(unitResults, cucumberResults)
-  } else if(desc.getName().contains("cucumber")) {
-    cucumberResults = resolveTestResult(cucumberResults, result)
-  } else if(desc.getName().contains("pingis")) {
-    unitResults = resolveTestResult(unitResults, result)
+    println formatResults(result, type)
   }
 }
 
-//Updates the totals for the test counts
-def resolveTestResult(results, newResult) { 
-  def succ = newResult.getSuccessfulTestCount()
-  def fail = newResult.getFailedTestCount()
-  def skip = newResult.getSkippedTestCount()
-  return [results[0]+succ,results[1]+fail,results[2]+skip]
-}
-
 //Formats and colors the final results for printing
-def formatResults(unitRes, cukeRes) {
-  def unitColor = resultColor(unitRes)
-  def cukeColor = resultColor(cukeRes)
-  def stopColor = '[0m' //CLEAR FORMATTING
+def formatResults(res, type) {
+  def succ = res.getSuccessfulTestCount()
+  def fail = res.getFailedTestCount()
+  def skip = res.getSkippedTestCount()
+
+  def color = resultColor(fail, skip)
+  def stopColor = '[0m' //CLEARS FORMATTING
+
+  def report
+  if(type == 'UNIT') report = '/build/reports/tests/test/index.html'
+  if(type == 'CUKE') report = '/build/reports/tests/cucumber/index.html'
+
   return '\n' +
     '========================================================================================================================\n' +
-    (char)27 + unitColor +
-    'UNIT SUCCESSFUL:'+ unitRes[0] +', FAILED:'+ unitRes[1] +', SKIPPED:'+ unitRes[2] +'. file://' +file('.')+ '/build/reports/tests/test/index.html\n'+
-    (char)27 + cukeColor +
-    'CUKE SUCCESSFUL:'+ cukeRes[0] +', FAILED:'+ cukeRes[1] +', SKIPPED:'+ cukeRes[2] +'. file://' +file('.')+ '/build/reports/tests/cucumber/index.html\n' +
+    (char)27 + color +
+    type +' SUCCESSFUL:'+ succ +', FAILED:'+ fail +', SKIPPED:'+ skip +'. file://' +file('.')+ report + '\n' +
     (char)27 + stopColor +
     '========================================================================================================================\n'
 }
 
-def resultColor(res) {
-  if(res[1] > 0) return '[31m' //RED
-  if(res[2] > 0) return '[33m' //YELLOW
+def resultColor(fail, skip) {
+  if(fail > 0) return '[31m' //RED
+  if(skip > 0) return '[33m' //YELLOW
   return '[32m' //GREEN
 }


### PR DESCRIPTION
Either test type can now be excluded with '-x unitTest' or '-x cucumberTest'