### PR TITLE
Profile properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ VOLUME /tmp
 
 # Add the jar and the properties to the working directory of the container
 ADD build/libs/tdd-pingpong-0.1.0.jar app.jar
-ADD application.properties .
+ADD config/ .
 
 
 # Static files, such as index.html, supposedly need a modification time, which are set when created by touch

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ bootRun {
         environment 'TMC_APP_ID', "dummy"
         environment 'TMC_SECRET', "dummy"
     }
+	systemProperties System.properties
 }
 
 

--- a/config/application-dev.yml
+++ b/config/application-dev.yml
@@ -1,0 +1,9 @@
+tmc:
+  sandboxUrl: http://localhost:3001
+  notifyUrl: http://localhost:1337/submission-result
+
+security:
+  oauth2:
+    client:
+      tmc:
+        redirectUri: http://localhost:8080/oauth2/authorize/code/tmc

--- a/config/application-prod.yml
+++ b/config/application-prod.yml
@@ -1,6 +1,6 @@
 tmc:
   sandboxUrl: http://172.17.0.1:3001
-  notifyUrl: http://localhost:3000/submission-result
+  notifyUrl: http://pingis.testmycode.io/submission-result
 
 security:
   oauth2:

--- a/config/application-prod.yml
+++ b/config/application-prod.yml
@@ -6,4 +6,4 @@ security:
   oauth2:
     client:
       tmc:
-        redirectUri: http://pingis.testmycode.io/oauth2/authorize/code/tmc
+        redirectUri: https://pingis.testmycode.io/oauth2/authorize/code/tmc

--- a/config/application-prod.yml
+++ b/config/application-prod.yml
@@ -1,0 +1,9 @@
+tmc:
+  sandboxUrl: http://172.17.0.1:3001
+  notifyUrl: http://localhost:3000/submission-result
+
+security:
+  oauth2:
+    client:
+      tmc:
+        redirectUri: http://pingis.testmycode.io/oauth2/authorize/code/tmc

--- a/config/application.yml
+++ b/config/application.yml
@@ -11,17 +11,12 @@ spring:
   profiles:
     default: dev
 
-tmc:
-  sandboxUrl: http://localhost:3001
-  notifyUrl: http://localhost:1337/submission-result
-
 security:
   oauth2:
     client:
       tmc:
         clientAuthenticationMethod: basic
         authorizedGrantType: authorization_code
-        redirectUri: http://localhost:8080/oauth2/authorize/code/tmc
         authorizationUri: https://tmc.mooc.fi/oauth/authorize
         tokenUri: https://tmc.mooc.fi/oauth/token
         userInfoUri: https://tmc.mooc.fi/api/v8/users/current

--- a/config/application.yml
+++ b/config/application.yml
@@ -9,7 +9,7 @@ spring:
     password: ""
     driverClassName: org.h2.Driver
   profiles:
-    active: prod
+    default: dev
 
 tmc:
   sandboxUrl: http://localhost:3001


### PR DESCRIPTION
Move properties files to config directory, add some defaults for the production properties file, set default profile to 'dev', make bootRun accept profile as argument (example: ./gradlew bootRun -Dspring.profiles.active=oauth -x test)