### PR TITLE
Fix cucumber test index path in print cleaning script

### DIFF
--- a/gradle/helpers/test-printing.gradle
+++ b/gradle/helpers/test-printing.gradle
@@ -19,7 +19,7 @@ def formatResults(res, type) {
 
   def report
   if(type == 'UNIT') report = '/build/reports/tests/test/index.html'
-  if(type == 'CUKE') report = '/build/reports/tests/cucumber/index.html'
+  if(type == 'CUKE') report = '/build/reports/tests/cucumberTest/index.html'
 
   return '\n' +
     '========================================================================================================================\n' +


### PR DESCRIPTION
The hardcoded classpath for the cucumber tests changed in 6e5787f.