### PR TITLE
Use ChallengeService for context configuration.

### DIFF
--- a/src/test/java/pingis/services/ChallengeServiceTest.java
+++ b/src/test/java/pingis/services/ChallengeServiceTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = {ChallengeService.class})
 public class ChallengeServiceTest {
 
     @Autowired


### PR DESCRIPTION
Using `Application.class` for context configuration in a unit test pulls in a lot of dependencies and generates a ton of debug output, making Travis truncate the log.