### PR TITLE
Moved the properties from application-dev and application-oauth

### DIFF
--- a/config/application-dev.yml
+++ b/config/application-dev.yml
@@ -1,9 +1,0 @@
-tmc:
-  sandboxUrl: http://localhost:3001
-  notifyUrl: http://localhost:1337/submission-result
-
-security:
-  oauth2:
-    client:
-      tmc:
-        redirectUri: http://localhost:8080/oauth2/authorize/code/tmc

--- a/config/application-oauth.yml
+++ b/config/application-oauth.yml
@@ -1,5 +1,0 @@
-security:
-  oauth2:
-    client:
-      tmc:
-        redirectUri: http://localhost:8080/oauth2/authorize/code/tmc

--- a/config/application.yml
+++ b/config/application.yml
@@ -25,3 +25,8 @@ security:
         scopes: public
         clientName: TMC
         clientAlias: tmc
+        redirectUri: http://localhost:8080/oauth2/authorize/code/tmc
+
+tmc:
+  sandboxUrl: http://localhost:3001
+  notifyUrl: http://localhost:1337/submission-result


### PR DESCRIPTION
The TMC submission didn't function with the oauth profile due to missing TMC sandbox information in its application-oauth.yml. Since the settings are sensible defaults for any development profile and currently shared by dev and oauth, I moved them into application.yml. They can be overridden by any profile in their own configuration file as is done in application-prod.yml now.