### PR TITLE
Use Instance instead of Implementation for names.

### DIFF
--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -40,7 +40,7 @@ public class TaskController {
     @Autowired
     EditorService editorService;
     @Autowired
-    TaskImplementationService taskImplementationService;
+    TaskInstanceService taskInstanceService;
 
 
     @Autowired
@@ -55,7 +55,7 @@ public class TaskController {
             @PathVariable Long taskImplementationId) {
 
         TaskInstance taskInstance =
-                taskImplementationService.findOne(taskImplementationId);
+                taskInstanceService.findOne(taskImplementationId);
         if (taskInstance == null) {
             model.addAttribute("errormessage","no such task implementation");
             return "error";
@@ -121,7 +121,7 @@ public class TaskController {
                              String staticCode,
                              long taskImplementationId,
                              RedirectAttributes redirectAttributes) throws IOException, ArchiveException {
-        TaskInstance taskInstance = taskImplementationService.findOne(taskImplementationId);
+        TaskInstance taskInstance = taskInstanceService.findOne(taskImplementationId);
         Task currentTask = taskInstance.getTask();
 
         Challenge currentChallenge = currentTask.getChallenge();
@@ -139,7 +139,7 @@ public class TaskController {
         redirectAttributes.addAttribute("submission", submission);
 
         // Save user's answer from left editor
-        taskImplementationService.updateTaskImplementationCode(taskImplementationId, submissionCode);
+        taskInstanceService.updateTaskInstanceCode(taskImplementationId, submissionCode);
         logger.debug("Redirecting to feedback");
         return new RedirectView("/feedback");
     }

--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -50,20 +50,20 @@ public class TaskController {
     private SubmissionSenderService senderService;
 
 
-    @RequestMapping(value = "/task/{taskImplementationId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/task/{taskInstanceId}", method = RequestMethod.GET)
     public String task(Model model,
-            @PathVariable Long taskImplementationId) {
+            @PathVariable Long taskInstanceId) {
 
         TaskInstance taskInstance =
-                taskInstanceService.findOne(taskImplementationId);
+                taskInstanceService.findOne(taskInstanceId);
         if (taskInstance == null) {
-            model.addAttribute("errormessage","no such task implementation");
+            model.addAttribute("errormessage","no such task instance");
             return "error";
         }
         Challenge currentChallenge = taskInstance.getTask().getChallenge();
         model.addAttribute("challenge", currentChallenge);
         model.addAttribute("task", taskInstance.getTask());
-        model.addAttribute("taskImplementationId", taskImplementationId);
+        model.addAttribute("taskInstanceId", taskInstanceId);
         Map<String, EditorTabData> editorContents = editorService.generateEditorContents(taskInstance);
         model.addAttribute("submissionCodeStub", editorContents.get("editor1").code);
         model.addAttribute("staticCode", editorContents.get("editor2").code);
@@ -119,19 +119,19 @@ public class TaskController {
     @RequestMapping(value = "/task", method = RequestMethod.POST)
     public RedirectView task(String submissionCode,
                              String staticCode,
-                             long taskImplementationId,
+                             long taskInstanceId,
                              RedirectAttributes redirectAttributes) throws IOException, ArchiveException {
-        TaskInstance taskInstance = taskInstanceService.findOne(taskImplementationId);
+        TaskInstance taskInstance = taskInstanceService.findOne(taskInstanceId);
         Task currentTask = taskInstance.getTask();
 
         Challenge currentChallenge = currentTask.getChallenge();
-        redirectAttributes.addAttribute("taskImplementationId", taskImplementationId);
+        redirectAttributes.addAttribute("taskInstanceId", taskInstanceId);
 
         String[] errors = checkErrors(submissionCode, staticCode);
         if (errors != null) {
             redirectAttributes.addFlashAttribute("errors", errors);
             redirectAttributes.addFlashAttribute("code", submissionCode);
-            return new RedirectView("/task/{taskImplementationId}");
+            return new RedirectView("/task/{taskInstanceId}");
         }
      
         TmcSubmission submission = submitToTmc(taskInstance, currentChallenge, submissionCode, staticCode);
@@ -139,7 +139,7 @@ public class TaskController {
         redirectAttributes.addAttribute("submission", submission);
 
         // Save user's answer from left editor
-        taskInstanceService.updateTaskInstanceCode(taskImplementationId, submissionCode);
+        taskInstanceService.updateTaskInstanceCode(taskInstanceId, submissionCode);
         logger.debug("Redirecting to feedback");
         return new RedirectView("/feedback");
     }

--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import pingis.entities.ImplementationType;
+import pingis.entities.TaskType;
 import pingis.entities.TaskInstance;
 
 import pingis.entities.tmc.TmcSubmission;
@@ -70,7 +70,7 @@ public class TaskController {
         String implFileName = JavaClassGenerator.generateImplClassFilename(currentChallenge);
         String testFileName = JavaClassGenerator.generateTestClassFilename(currentChallenge);
         
-        if (taskInstance.getTask().getType() == ImplementationType.TEST) {
+        if (taskInstance.getTask().getType() == TaskType.TEST) {
             model.addAttribute("submissionTabFileName", testFileName);
             model.addAttribute("staticTabFileName", implFileName);
         } else {
@@ -102,7 +102,7 @@ public class TaskController {
         String implFileName = JavaClassGenerator.generateImplClassFilename(challenge);
         String testFileName = JavaClassGenerator.generateTestClassFilename(challenge);
 
-        if (taskInstance.getTask().getType() == ImplementationType.TEST) {
+        if (taskInstance.getTask().getType() == TaskType.TEST) {
             files.put(testFileName, submissionCode.getBytes());
             files.put(implFileName, staticCode.getBytes());
         } else {

--- a/src/main/java/pingis/entities/Task.java
+++ b/src/main/java/pingis/entities/Task.java
@@ -34,7 +34,7 @@ public class Task {
     private String desc;
     
     @NotNull
-    private ImplementationType type;
+    private TaskType type;
 
     @NotNull
     private String codeStub;
@@ -58,8 +58,8 @@ public class Task {
 
     protected Task() {}
     
-    public Task(int index,  ImplementationType type, User author,
-            String name, String desc, String codeStub, int level, int rating) {
+    public Task(int index, TaskType type, User author,
+                String name, String desc, String codeStub, int level, int rating) {
         this.index = index;
         this.type = type;
         this.author = author;
@@ -151,20 +151,20 @@ public class Task {
         this.index = index;
     }
 
-    public ImplementationType getType() {
+    public TaskType getType() {
         return type;
     }
 
-    public void setType(ImplementationType type) {
+    public void setType(TaskType type) {
         this.type = type;
     }
 
     public void setTypeTest() {
-        this.type = ImplementationType.TEST;
+        this.type = TaskType.TEST;
     }
 
     public void setTypeImplementation() {
-        this.type = ImplementationType.IMPLEMENTATION;
+        this.type = TaskType.IMPLEMENTATION;
     }
 
 }

--- a/src/main/java/pingis/entities/Task.java
+++ b/src/main/java/pingis/entities/Task.java
@@ -6,12 +6,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import java.util.List;
 import java.util.ArrayList;
-import javax.persistence.CascadeType;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.*;
-import pingis.entities.tmc.TmcSubmission;
 
 @Entity
 public class Task {
@@ -56,7 +54,7 @@ public class Task {
     private User author;
 
     @OneToMany(fetch=FetchType.LAZY, mappedBy="task")
-    private List<TaskImplementation> implementations;
+    private List<TaskInstance> taskInstances;
 
     protected Task() {}
     
@@ -70,15 +68,15 @@ public class Task {
         this.codeStub = codeStub;
         this.level = level;
         this.rating = rating;
-        this.implementations = new ArrayList<>();
+        this.taskInstances = new ArrayList<>();
     }
 
     public void setAuthor(User author) {
         this.author = author;
     }
 
-    public void addImplementation(TaskImplementation taskImplementation) {
-        this.implementations.add(taskImplementation);
+    public void addTaskInstance(TaskInstance taskInstance) {
+        this.taskInstances.add(taskInstance);
     }
 
     public User getAuthor() {
@@ -137,12 +135,12 @@ public class Task {
         this.level = level;
     }
 
-    public List<TaskImplementation> getImplementations() {
-        return this.implementations;
+    public List<TaskInstance> getTaskInstances() {
+        return this.taskInstances;
     }
 
-    public void setImplementations(List<TaskImplementation> implementations) {
-        this.implementations = implementations;
+    public void setTaskInstances(List<TaskInstance> taskInstances) {
+        this.taskInstances = taskInstances;
     }
 
     public int getIndex() {

--- a/src/main/java/pingis/entities/TaskInstance.java
+++ b/src/main/java/pingis/entities/TaskInstance.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 import pingis.entities.tmc.TmcSubmission;
 
 @Entity
-public class TaskImplementation {
+public class TaskInstance {
     @Id
     @GeneratedValue(strategy=GenerationType.AUTO)
     private long id;
@@ -38,9 +38,9 @@ public class TaskImplementation {
     @ManyToOne(fetch=FetchType.EAGER)
     private User user;
 
-    protected TaskImplementation() {}
+    protected TaskInstance() {}
 
-    public TaskImplementation(User user, String code, Task task) {
+    public TaskInstance(User user, String code, Task task) {
         this.user = user;
         this.code = code;
         this.task = task;

--- a/src/main/java/pingis/entities/TaskType.java
+++ b/src/main/java/pingis/entities/TaskType.java
@@ -1,7 +1,7 @@
 
 package pingis.entities;
 
-public enum ImplementationType {
+public enum TaskType {
     TEST, IMPLEMENTATION
 }
 

--- a/src/main/java/pingis/entities/User.java
+++ b/src/main/java/pingis/entities/User.java
@@ -32,7 +32,7 @@ public class User {
     private int level;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
-    private List<TaskImplementation> taskImplementations;
+    private List<TaskInstance> taskInstances;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "author")
     private List<Challenge> authoredChallenges;
@@ -57,7 +57,7 @@ public class User {
         this.name = name;
         this.level = level;
         this.administrator = isAdministrator;
-        this.taskImplementations = new ArrayList<>();
+        this.taskInstances = new ArrayList<>();
         this.authoredChallenges = new ArrayList<>();
         this.authoredTasks = new ArrayList<>();
     }
@@ -98,12 +98,12 @@ public class User {
         this.level = level;
     }
 
-    public void setTaskImplementations(List<TaskImplementation> taskImplementations) {
-        this.taskImplementations = taskImplementations;
+    public void setTaskInstances(List<TaskInstance> taskInstances) {
+        this.taskInstances = taskInstances;
     }
 
-    public List<TaskImplementation> getTaskImplementations() {
-        return this.taskImplementations;
+    public List<TaskInstance> getTaskInstances() {
+        return this.taskInstances;
     }
     
     public List<Challenge> getAuthoredChallenges() {

--- a/src/main/java/pingis/entities/tmc/TmcSubmission.java
+++ b/src/main/java/pingis/entities/tmc/TmcSubmission.java
@@ -2,7 +2,7 @@ package pingis.entities.tmc;
 
 import javax.persistence.*;
 import java.util.UUID;
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 
 /**
  * Created by dwarfcrank on 7/28/17.
@@ -32,7 +32,7 @@ public class TmcSubmission {
     private String vmLog;
     
     @OneToOne
-    private TaskImplementation taskImplementation;
+    private TaskInstance taskInstance;
 
     public UUID getId() {
         return id;
@@ -102,11 +102,11 @@ public class TmcSubmission {
         this.vmLog = vmLog;
     }
 
-    public void setTaskImplementation(TaskImplementation taskImplementation) {
-        this.taskImplementation = taskImplementation;
+    public void setTaskInstance(TaskInstance taskInstance) {
+        this.taskInstance = taskInstance;
     }
 
-    public TaskImplementation getTaskImplementation() {
-        return taskImplementation;
+    public TaskInstance getTaskInstance() {
+        return taskInstance;
     }
 }

--- a/src/main/java/pingis/repositories/TaskImplementationRepository.java
+++ b/src/main/java/pingis/repositories/TaskImplementationRepository.java
@@ -2,15 +2,15 @@
  */
 package pingis.repositories;
 
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import org.springframework.data.repository.CrudRepository;
 import pingis.entities.Task;
 import pingis.entities.User;
 
-public interface TaskImplementationRepository extends CrudRepository<TaskImplementation, Long> {
+public interface TaskImplementationRepository extends CrudRepository<TaskInstance, Long> {
     
 //    @Query("delete From Reference r Where r.name = ?1")
 //    void deleteReferenceByName(String name);
-    TaskImplementation findByTaskAndUser(Task task, User user);
+    TaskInstance findByTaskAndUser(Task task, User user);
 
 }

--- a/src/main/java/pingis/repositories/TaskInstanceRepository.java
+++ b/src/main/java/pingis/repositories/TaskInstanceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.CrudRepository;
 import pingis.entities.Task;
 import pingis.entities.User;
 
-public interface TaskImplementationRepository extends CrudRepository<TaskInstance, Long> {
+public interface TaskInstanceRepository extends CrudRepository<TaskInstance, Long> {
     
 //    @Query("delete From Reference r Where r.name = ?1")
 //    void deleteReferenceByName(String name);

--- a/src/main/java/pingis/services/DataImporter.java
+++ b/src/main/java/pingis/services/DataImporter.java
@@ -170,13 +170,13 @@ public class DataImporter implements ApplicationRunner {
         String codeStub = assembleString(codeArray);
         
         String taskType = taskObject.getString("type");
-        ImplementationType type;
+        TaskType type;
         Task task;
         
         if (taskType.equals("test")) {
-            task = createTask(ImplementationType.TEST, author, taskObject, codeStub, challenge);
+            task = createTask(TaskType.TEST, author, taskObject, codeStub, challenge);
         } else {
-            task = createTask(ImplementationType.IMPLEMENTATION, author, taskObject, codeStub, challenge);            
+            task = createTask(TaskType.IMPLEMENTATION, author, taskObject, codeStub, challenge);
         }
         String modelImp = "";
         JSONArray modelImpArray = taskObject.getJSONArray("modelimplementation");
@@ -195,8 +195,8 @@ public class DataImporter implements ApplicationRunner {
         return taskInstance;
     }
 
-    private Task createTask(ImplementationType type, User author, JSONObject taskObject, 
-                        String codeStub, Challenge challenge) {
+    private Task createTask(TaskType type, User author, JSONObject taskObject,
+                            String codeStub, Challenge challenge) {
         Task task = new Task(taskObject.getInt("index"), type, author,
                 taskObject.getString("name"),
                 taskObject.getString("desc"),

--- a/src/main/java/pingis/services/DataImporter.java
+++ b/src/main/java/pingis/services/DataImporter.java
@@ -152,7 +152,7 @@ public class DataImporter implements ApplicationRunner {
             // a challenge start from zero.
             this.taskid = 0;
         }
-        this.createDummyImplementations(jsonImportObject.getJSONArray("dummyimplementations"));
+        this.createDummyInstances(jsonImportObject.getJSONArray("dummyimplementations"));
 
     }
 
@@ -207,14 +207,14 @@ public class DataImporter implements ApplicationRunner {
         return task;
     }
     
-    private void createDummyImplementations(JSONArray implementations) {
-        for (int i = 0; i < implementations.length(); i++) {
-            JSONObject implementation = implementations.getJSONObject(i);
-            JSONArray taskImplementations = implementation.getJSONArray("taskimplementations");
-            for (int j = 0; j < taskImplementations.length(); j++) {
-                JSONObject implementationObject = taskImplementations.getJSONObject(j);
+    private void createDummyInstances(JSONArray instances) {
+        for (int i = 0; i < instances.length(); i++) {
+            JSONObject instance = instances.getJSONObject(i);
+            JSONArray taskInstances = instance.getJSONArray("taskinstances");
+            for (int j = 0; j < taskInstances.length(); j++) {
+                JSONObject implementationObject = taskInstances.getJSONObject(j);
                 User user = users.get(implementationObject.getString("user"));
-                List<Task> tasks = this.challenges.get(implementation.getString("challenge")).getTasks();
+                List<Task> tasks = this.challenges.get(instance.getString("challenge")).getTasks();
                 Task task = tasks.get(implementationObject.getInt("taskindex")-1);
                 TaskInstance taskInstance =
                         createTaskInstance(
@@ -263,7 +263,7 @@ public class DataImporter implements ApplicationRunner {
             System.out.println("key: "+key+", value: "+this.users.get(key).toString()+"\n");
         }
         printChallenges();
-        printTaskImplementations();
+        printTaskInstances();
     }
 
     private void printChallenges() {
@@ -278,9 +278,9 @@ public class DataImporter implements ApplicationRunner {
         }
     }
 
-    private void printTaskImplementations() {
+    private void printTaskInstances() {
         System.out.println("---");
-        System.out.println("taskimplementations:");
+        System.out.println("taskinstances:");
         for (TaskInstance i : this.taskInstances) {
             System.out.println("ti: "+i.toString());
             System.out.println("-");

--- a/src/main/java/pingis/services/DataImporter.java
+++ b/src/main/java/pingis/services/DataImporter.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import pingis.entities.*;
 import pingis.entities.TaskInstance;
 import pingis.repositories.ChallengeRepository;
-import pingis.repositories.TaskImplementationRepository;
+import pingis.repositories.TaskInstanceRepository;
 import pingis.repositories.TaskRepository;
 
 @Component
@@ -27,7 +27,7 @@ public class DataImporter implements ApplicationRunner {
     private ChallengeRepository cr;
     private TaskRepository tr;
     private UserService us;
-    private TaskImplementationRepository tir;
+    private TaskInstanceRepository tir;
     private HashMap<String, User> users = new LinkedHashMap();
     private HashMap<String, Challenge> challenges = new HashMap();
     private ArrayList<Task> tasks = new ArrayList();
@@ -62,7 +62,7 @@ public class DataImporter implements ApplicationRunner {
     
     @Autowired
     public DataImporter(ChallengeRepository cr, TaskRepository tr, UserService ps,
-            TaskImplementationRepository tir) {
+            TaskInstanceRepository tir) {
         this.cr = cr;
         this.tr = tr;
         this.us = ps;

--- a/src/main/java/pingis/services/DataImporter.java
+++ b/src/main/java/pingis/services/DataImporter.java
@@ -11,11 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
-import pingis.entities.Challenge;
-import pingis.entities.ImplementationType;
-import pingis.entities.Task;
-import pingis.entities.TaskImplementation;
-import pingis.entities.User;
+import pingis.entities.*;
+import pingis.entities.TaskInstance;
 import pingis.repositories.ChallengeRepository;
 import pingis.repositories.TaskImplementationRepository;
 import pingis.repositories.TaskRepository;
@@ -34,7 +31,7 @@ public class DataImporter implements ApplicationRunner {
     private HashMap<String, User> users = new LinkedHashMap();
     private HashMap<String, Challenge> challenges = new HashMap();
     private ArrayList<Task> tasks = new ArrayList();
-    private ArrayList<TaskImplementation> taskImplementations = new ArrayList();
+    private ArrayList<TaskInstance> taskInstances = new ArrayList();
     private int taskid = 0;
 
     public enum UserType {
@@ -130,8 +127,8 @@ public class DataImporter implements ApplicationRunner {
         return tasks;
     }
 
-    public ArrayList<TaskImplementation> getTaskImplementations() {
-        return taskImplementations;
+    public ArrayList<TaskInstance> getTaskInstances() {
+        return taskInstances;
     }
 
     public void generateEntities() {
@@ -184,18 +181,18 @@ public class DataImporter implements ApplicationRunner {
         String modelImp = "";
         JSONArray modelImpArray = taskObject.getJSONArray("modelimplementation");
         modelImp = assembleString(modelImpArray);
-        TaskImplementation taskImplementation = createTaskImplementation(author, modelImp, task);
+        TaskInstance taskInstance = createTaskInstance(author, modelImp, task);
         
-        this.taskImplementations.add(taskImplementation);
+        this.taskInstances.add(taskInstance);
     }
 
-    private TaskImplementation createTaskImplementation(User author, String modelImp, 
-                        Task task) {
-        // Create new TaskImplementation
-        TaskImplementation taskImplementation = new TaskImplementation(author, modelImp, task);
-        task.addImplementation(taskImplementation);
+    private TaskInstance createTaskInstance(User author, String modelImp,
+                                            Task task) {
+        // Create new TaskInstance
+        TaskInstance taskInstance = new TaskInstance(author, modelImp, task);
+        task.addTaskInstance(taskInstance);
         
-        return taskImplementation;
+        return taskInstance;
     }
 
     private Task createTask(ImplementationType type, User author, JSONObject taskObject, 
@@ -219,11 +216,11 @@ public class DataImporter implements ApplicationRunner {
                 User user = users.get(implementationObject.getString("user"));
                 List<Task> tasks = this.challenges.get(implementation.getString("challenge")).getTasks();
                 Task task = tasks.get(implementationObject.getInt("taskindex")-1);
-                TaskImplementation taskImplementation =
-                        createTaskImplementation(
+                TaskInstance taskInstance =
+                        createTaskInstance(
                                 user,"",
                                 task);
-                this.taskImplementations.add(taskImplementation);
+                this.taskInstances.add(taskInstance);
             }
         }
     }
@@ -253,7 +250,7 @@ public class DataImporter implements ApplicationRunner {
         }
 
 
-        for (TaskImplementation i : this.taskImplementations) {
+        for (TaskInstance i : this.taskInstances) {
             tir.save(i);
         }
     }
@@ -284,7 +281,7 @@ public class DataImporter implements ApplicationRunner {
     private void printTaskImplementations() {
         System.out.println("---");
         System.out.println("taskimplementations:");
-        for (TaskImplementation i : this.taskImplementations) {
+        for (TaskInstance i : this.taskInstances) {
             System.out.println("ti: "+i.toString());
             System.out.println("-");
         }

--- a/src/main/java/pingis/services/EditorService.java
+++ b/src/main/java/pingis/services/EditorService.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import pingis.entities.Challenge;
 import pingis.entities.ImplementationType;
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import pingis.utils.JavaClassGenerator;
 
 @Service
@@ -20,44 +20,44 @@ public class EditorService {
     public EditorService() {
     }
 
-    public Map<String, EditorTabData> generateEditorContents(TaskImplementation taskImplementation) {
+    public Map<String, EditorTabData> generateEditorContents(TaskInstance taskInstance) {
         Map<String, EditorTabData> tabData;
-        Challenge currentChallenge = taskImplementation.getTask().getChallenge();
-        if (taskImplementation.getTask().getType().equals(ImplementationType.TEST)) {
-            tabData = this.generateTestTaskTabs(taskImplementation, currentChallenge);
+        Challenge currentChallenge = taskInstance.getTask().getChallenge();
+        if (taskInstance.getTask().getType().equals(ImplementationType.TEST)) {
+            tabData = this.generateTestTaskTabs(taskInstance, currentChallenge);
         } else {
-            tabData = this.generateImplTaskTabs(taskImplementation, currentChallenge);
+            tabData = this.generateImplTaskTabs(taskInstance, currentChallenge);
         }
         return tabData;
     }
 
-    private Map<String, EditorTabData> generateTestTaskTabs(TaskImplementation taskImplementation,
+    private Map<String, EditorTabData> generateTestTaskTabs(TaskInstance taskInstance,
             Challenge currentChallenge) {
         Map<String, EditorTabData> tabData = new LinkedHashMap();
-        TaskImplementation implTaskImplementation
-                = taskImplementationService.getCorrespondingImplTaskImplementation(taskImplementation);
+        TaskInstance implTaskInstance
+                = taskImplementationService.getCorrespondingImplTaskInstance(taskInstance);
         EditorTabData tab1 = new EditorTabData(
                 JavaClassGenerator.generateTestClassFilename(currentChallenge),
-                taskImplementation.getTask().getCodeStub());
+                taskInstance.getTask().getCodeStub());
         EditorTabData tab2 = new EditorTabData(
                 JavaClassGenerator.generateImplClassFilename(currentChallenge),
-                implTaskImplementation.getTask().getCodeStub());
+                implTaskInstance.getTask().getCodeStub());
         tabData.put("editor1", tab1);
         tabData.put("editor2", tab2);
         return tabData;
     }
 
-    private Map<String, EditorTabData> generateImplTaskTabs(TaskImplementation taskImplementation,
+    private Map<String, EditorTabData> generateImplTaskTabs(TaskInstance taskInstance,
             Challenge currentChallenge) {
         Map<String, EditorTabData> tabData = new LinkedHashMap();
-        TaskImplementation testTaskImplementation
-                = taskImplementationService.getCorrespondingTestTaskImplementation(
-                        taskImplementation);
+        TaskInstance testTaskInstance
+                = taskImplementationService.getCorrespondingTestTaskInstance(
+                taskInstance);
         EditorTabData tab2 = new EditorTabData(
                 "Implement code here",
-                taskImplementation.getTask().getCodeStub());
+                taskInstance.getTask().getCodeStub());
         EditorTabData tab1 = new EditorTabData("Test to fulfill",
-                testTaskImplementation
+                testTaskInstance
                         .getCode());
         tabData.put("editor2", tab1);
         tabData.put("editor1", tab2);

--- a/src/main/java/pingis/services/EditorService.java
+++ b/src/main/java/pingis/services/EditorService.java
@@ -7,7 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import pingis.entities.Challenge;
-import pingis.entities.ImplementationType;
+import pingis.entities.TaskType;
 import pingis.entities.TaskInstance;
 import pingis.utils.JavaClassGenerator;
 
@@ -23,7 +23,7 @@ public class EditorService {
     public Map<String, EditorTabData> generateEditorContents(TaskInstance taskInstance) {
         Map<String, EditorTabData> tabData;
         Challenge currentChallenge = taskInstance.getTask().getChallenge();
-        if (taskInstance.getTask().getType().equals(ImplementationType.TEST)) {
+        if (taskInstance.getTask().getType().equals(TaskType.TEST)) {
             tabData = this.generateTestTaskTabs(taskInstance, currentChallenge);
         } else {
             tabData = this.generateImplTaskTabs(taskInstance, currentChallenge);

--- a/src/main/java/pingis/services/EditorService.java
+++ b/src/main/java/pingis/services/EditorService.java
@@ -15,7 +15,7 @@ import pingis.utils.JavaClassGenerator;
 public class EditorService {
     
     @Autowired
-    TaskImplementationService taskImplementationService;
+    TaskInstanceService taskInstanceService;
     
     public EditorService() {
     }
@@ -35,7 +35,7 @@ public class EditorService {
             Challenge currentChallenge) {
         Map<String, EditorTabData> tabData = new LinkedHashMap();
         TaskInstance implTaskInstance
-                = taskImplementationService.getCorrespondingImplTaskInstance(taskInstance);
+                = taskInstanceService.getCorrespondingImplTaskInstance(taskInstance);
         EditorTabData tab1 = new EditorTabData(
                 JavaClassGenerator.generateTestClassFilename(currentChallenge),
                 taskInstance.getTask().getCodeStub());
@@ -51,7 +51,7 @@ public class EditorService {
             Challenge currentChallenge) {
         Map<String, EditorTabData> tabData = new LinkedHashMap();
         TaskInstance testTaskInstance
-                = taskImplementationService.getCorrespondingTestTaskInstance(
+                = taskInstanceService.getCorrespondingTestTaskInstance(
                 taskInstance);
         EditorTabData tab2 = new EditorTabData(
                 "Implement code here",

--- a/src/main/java/pingis/services/TaskImplementationService.java
+++ b/src/main/java/pingis/services/TaskImplementationService.java
@@ -4,7 +4,7 @@ package pingis.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import pingis.repositories.TaskImplementationRepository;
 import pingis.repositories.TaskRepository;
 import pingis.repositories.UserRepository;
@@ -21,35 +21,35 @@ public class TaskImplementationService {
 
 
     
-    public TaskImplementation getCorrespondingTestTaskImplementation(
-            TaskImplementation implTaskImplementation) {
+    public TaskInstance getCorrespondingTestTaskInstance(
+            TaskInstance implTaskInstance) {
         return taskImplementationRepository.
                 findByTaskAndUser(
                         taskRepository.
-                                findByIndexAndChallenge(implTaskImplementation.getTask().getIndex()-1,
-                                        implTaskImplementation.getTask().getChallenge()),
+                                findByIndexAndChallenge(implTaskInstance.getTask().getIndex()-1,
+                                        implTaskInstance.getTask().getChallenge()),
                         userRepository.findOne(0l));
     }
     
 
     
-    public TaskImplementation getCorrespondingImplTaskImplementation(TaskImplementation testTaskImplementation) {
+    public TaskInstance getCorrespondingImplTaskInstance(TaskInstance testTaskInstance) {
         return taskImplementationRepository.
                 findByTaskAndUser(
-                        taskRepository.findByIndexAndChallenge(testTaskImplementation.getTask().getIndex()+1,
-                                testTaskImplementation.getTask().getChallenge()),
+                        taskRepository.findByIndexAndChallenge(testTaskInstance.getTask().getIndex()+1,
+                                testTaskInstance.getTask().getChallenge()),
                         userRepository.findOne(0l));
     }
 
-    public TaskImplementation findOne(long taskImplementationId) {
-        return taskImplementationRepository.findOne(taskImplementationId);
+    public TaskInstance findOne(long taskInstanceId) {
+        return taskImplementationRepository.findOne(taskInstanceId);
 
     }
 
     @Transactional
-    public TaskImplementation updateTaskImplementationCode(Long taskImplementationId, String taskImplementationCode) {
-        TaskImplementation taskImplementationToUpdate = taskImplementationRepository.findOne(taskImplementationId);
-        taskImplementationToUpdate.setCode(taskImplementationCode);
-        return taskImplementationToUpdate;
+    public TaskInstance updateTaskImplementationCode(Long taskInstanceId, String taskInstanceCode) {
+        TaskInstance taskInstanceToUpdate = taskImplementationRepository.findOne(taskInstanceId);
+        taskInstanceToUpdate.setCode(taskInstanceCode);
+        return taskInstanceToUpdate;
     }
 }

--- a/src/main/java/pingis/services/TaskImplementationService.java
+++ b/src/main/java/pingis/services/TaskImplementationService.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pingis.entities.TaskInstance;
-import pingis.repositories.TaskImplementationRepository;
+import pingis.repositories.TaskInstanceRepository;
 import pingis.repositories.TaskRepository;
 import pingis.repositories.UserRepository;
 
@@ -15,7 +15,7 @@ public class TaskImplementationService {
     @Autowired
     private TaskRepository taskRepository;
     @Autowired
-    private TaskImplementationRepository taskImplementationRepository;
+    private TaskInstanceRepository taskInstanceRepository;
     @Autowired
     private UserRepository userRepository;
 
@@ -23,7 +23,7 @@ public class TaskImplementationService {
     
     public TaskInstance getCorrespondingTestTaskInstance(
             TaskInstance implTaskInstance) {
-        return taskImplementationRepository.
+        return taskInstanceRepository.
                 findByTaskAndUser(
                         taskRepository.
                                 findByIndexAndChallenge(implTaskInstance.getTask().getIndex()-1,
@@ -34,7 +34,7 @@ public class TaskImplementationService {
 
     
     public TaskInstance getCorrespondingImplTaskInstance(TaskInstance testTaskInstance) {
-        return taskImplementationRepository.
+        return taskInstanceRepository.
                 findByTaskAndUser(
                         taskRepository.findByIndexAndChallenge(testTaskInstance.getTask().getIndex()+1,
                                 testTaskInstance.getTask().getChallenge()),
@@ -42,13 +42,13 @@ public class TaskImplementationService {
     }
 
     public TaskInstance findOne(long taskInstanceId) {
-        return taskImplementationRepository.findOne(taskInstanceId);
+        return taskInstanceRepository.findOne(taskInstanceId);
 
     }
 
     @Transactional
     public TaskInstance updateTaskImplementationCode(Long taskInstanceId, String taskInstanceCode) {
-        TaskInstance taskInstanceToUpdate = taskImplementationRepository.findOne(taskInstanceId);
+        TaskInstance taskInstanceToUpdate = taskInstanceRepository.findOne(taskInstanceId);
         taskInstanceToUpdate.setCode(taskInstanceCode);
         return taskInstanceToUpdate;
     }

--- a/src/main/java/pingis/services/TaskInstanceService.java
+++ b/src/main/java/pingis/services/TaskInstanceService.java
@@ -10,7 +10,7 @@ import pingis.repositories.TaskRepository;
 import pingis.repositories.UserRepository;
 
 @Service
-public class TaskImplementationService {
+public class TaskInstanceService {
 
     @Autowired
     private TaskRepository taskRepository;
@@ -47,7 +47,7 @@ public class TaskImplementationService {
     }
 
     @Transactional
-    public TaskInstance updateTaskImplementationCode(Long taskInstanceId, String taskInstanceCode) {
+    public TaskInstance updateTaskInstanceCode(Long taskInstanceId, String taskInstanceCode) {
         TaskInstance taskInstanceToUpdate = taskInstanceRepository.findOne(taskInstanceId);
         taskInstanceToUpdate.setCode(taskInstanceCode);
         return taskInstanceToUpdate;

--- a/src/main/java/pingis/services/TaskService.java
+++ b/src/main/java/pingis/services/TaskService.java
@@ -6,7 +6,7 @@ import pingis.entities.Task;
 import pingis.repositories.ChallengeRepository;
 import pingis.repositories.TaskRepository;
 import java.util.List;
-import pingis.repositories.TaskImplementationRepository;
+import pingis.repositories.TaskInstanceRepository;
 
 @Service
 public class TaskService {
@@ -16,7 +16,7 @@ public class TaskService {
     @Autowired
     private ChallengeRepository challengeRepository;
     @Autowired
-    private TaskImplementationRepository taskImplementationRepository;
+    private TaskInstanceRepository taskInstanceRepository;
 
     public Task findTaskInChallenge(Long challengeId, int taskId) {
         // Implement validation here

--- a/src/main/resources/exampledata/dummychallenges.json
+++ b/src/main/resources/exampledata/dummychallenges.json
@@ -101,7 +101,7 @@
             "challenge": "beginner 1",
             "testuser": "testuser",
             "implementationuser": "impluser",
-            "taskimplementations": [{
+            "taskinstances": [{
                     "user": "testuser",
                     "taskindex": 1
                 }]

--- a/src/main/resources/templates/task.html
+++ b/src/main/resources/templates/task.html
@@ -35,7 +35,7 @@
 
             <form method="post" th:action="@{/task}">
                 <div class="tab-content" th:inline="text">
-                    <input type="hidden" name="taskImplementationId" th:value="${taskImplementationId}" />
+                    <input type="hidden" name="taskInstanceId" th:value="${taskInstanceId}" />
                     <div id="implementation" class="panel panel-default tab-pane fade in active">
                         <div class="panel-heading">
                             <h3 class="panel-title" th:text="${submissionTabFileName}"></h3>

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -80,10 +80,10 @@ public class TaskControllerTest {
         challenge = new Challenge("Calculator", testUser,
                 "Simple calculator");
         testTask = new Task(1,
-                ImplementationType.TEST, testUser, "CalculatorAddition",
+                TaskType.TEST, testUser, "CalculatorAddition",
                 "Implement addition", "return 1+1;", 1, 1);
         implementationTask = new Task(2,
-                ImplementationType.IMPLEMENTATION, testUser, "implement addition",
+                TaskType.IMPLEMENTATION, testUser, "implement addition",
                 "implement addition", "public test", 1, 1);
         testTaskInstance
                 = new TaskInstance(testUser, "", testTask);

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -55,7 +55,7 @@ public class TaskControllerTest {
     private ChallengeService challengeServiceMock;
 
     @MockBean
-    private TaskImplementationService taskImplementationServiceMock;
+    private TaskInstanceService taskInstanceServiceMock;
             
     @MockBean
     private TaskService taskServiceMock;
@@ -103,16 +103,16 @@ public class TaskControllerTest {
 
     @Test
     public void givenTaskWhenGetTestTask() throws Exception {
-        when(taskImplementationServiceMock.findOne(testTaskInstance.getId()))
+        when(taskInstanceServiceMock.findOne(testTaskInstance.getId()))
                 .thenReturn(testTaskInstance);
         Map<String, EditorTabData> tabData = this.generateTestTabData(implTaskInstance, testTaskInstance);
         when(editorServiceMock.generateEditorContents(testTaskInstance)).thenReturn(tabData);
         String uri = "/task/"+ testTaskInstance.getId();
         performSimpleGetRequestAndFindContent(uri, "task", testTask.getCodeStub());
-        verify(taskImplementationServiceMock, times(1)).findOne(testTaskInstance.getId());
+        verify(taskInstanceServiceMock, times(1)).findOne(testTaskInstance.getId());
         verify(editorServiceMock, times(1))
                 .generateEditorContents(testTaskInstance);
-        verifyNoMoreInteractions(taskImplementationServiceMock);
+        verifyNoMoreInteractions(taskInstanceServiceMock);
         verifyNoMoreInteractions(editorServiceMock);
     }
     
@@ -120,16 +120,16 @@ public class TaskControllerTest {
     public void givenTaskWhenGetImplementationTask() throws Exception {
         User testUser = new User(1, "TESTUSER", 1);
 
-        when(taskImplementationServiceMock.findOne(implTaskInstance.getId()))
+        when(taskInstanceServiceMock.findOne(implTaskInstance.getId()))
                 .thenReturn(implTaskInstance);
         Map<String, EditorTabData> tabData = generateImplTabData(implTaskInstance, testTaskInstance);
         when(editorServiceMock.generateEditorContents(implTaskInstance)).thenReturn(tabData);
         String uri = "/task/" + implTaskInstance.getId();
         performSimpleGetRequestAndFindContent(uri, "task", implementationTask.getCodeStub());
-        verify(taskImplementationServiceMock, times(1)).findOne(implTaskInstance.getId());
+        verify(taskInstanceServiceMock, times(1)).findOne(implTaskInstance.getId());
         verify(editorServiceMock, times(1))
                 .generateEditorContents(implTaskInstance);
-        verifyNoMoreInteractions(taskImplementationServiceMock);
+        verifyNoMoreInteractions(taskInstanceServiceMock);
         verifyNoMoreInteractions(editorServiceMock);
     }
     
@@ -161,7 +161,7 @@ public class TaskControllerTest {
         String submissionCode = "/* this is an implementation */";
         String staticFileName = JavaClassGenerator.generateTestClassFilename(challenge);
         String staticCode = "/* this is a test */";
-        when(taskImplementationServiceMock.findOne(implTaskInstance.getId())).thenReturn(implTaskInstance);
+        when(taskInstanceServiceMock.findOne(implTaskInstance.getId())).thenReturn(implTaskInstance);
         when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
         when(taskServiceMock.findTaskInChallenge(challenge.getId(), testTask.getIndex())).thenReturn(testTask);
         mvc.perform(post("/task")
@@ -176,12 +176,12 @@ public class TaskControllerTest {
         assertArrayEquals(submissionCode.getBytes(), files.get(submissionFileName));
         assertArrayEquals(staticCode.getBytes(), files.get(staticFileName));
 
-        verify(taskImplementationServiceMock, times(1)).findOne(implTaskInstance.getId());
-        verify(taskImplementationServiceMock).updateTaskImplementationCode(implTaskInstance.getId(),
+        verify(taskInstanceServiceMock, times(1)).findOne(implTaskInstance.getId());
+        verify(taskInstanceServiceMock).updateTaskInstanceCode(implTaskInstance.getId(),
                                                                            submissionCode);
 
         verifyNoMoreInteractions(packagingService);
-        verifyNoMoreInteractions(taskImplementationServiceMock);
+        verifyNoMoreInteractions(taskInstanceServiceMock);
         verifyNoMoreInteractions(challengeServiceMock);
         verifyNoMoreInteractions(taskServiceMock);
     }

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -167,7 +167,7 @@ public class TaskControllerTest {
         mvc.perform(post("/task")
                 .param("submissionCode", submissionCode)
                 .param("staticCode", staticCode)
-                .param("taskImplementationId", Long.toString(implTaskInstance.getId())))
+                .param("taskInstanceId", Long.toString(implTaskInstance.getId())))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("/feedback*"));
         verify(packagingService).packageSubmission(packagingArgCaptor.capture());

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -17,10 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import pingis.config.SecurityDevConfig;
-import pingis.entities.Challenge;
-import pingis.entities.ImplementationType;
-import pingis.entities.Task;
-import pingis.entities.User;
+import pingis.entities.*;
 import pingis.services.*;
 import pingis.utils.JavaClassGenerator;
 
@@ -33,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import pingis.utils.EditorTabData;
 
 
@@ -73,8 +70,8 @@ public class TaskControllerTest {
     private Challenge challenge;
     private Task testTask;
     private Task implementationTask;
-    private TaskImplementation testTaskImplementation;
-    private TaskImplementation implTaskImplementation;
+    private TaskInstance testTaskInstance;
+    private TaskInstance implTaskInstance;
     private User testUser;
 
     @Before
@@ -88,9 +85,9 @@ public class TaskControllerTest {
         implementationTask = new Task(2,
                 ImplementationType.IMPLEMENTATION, testUser, "implement addition",
                 "implement addition", "public test", 1, 1);
-        testTaskImplementation
-                = new TaskImplementation(testUser, "", testTask);
-        implTaskImplementation = new TaskImplementation(testUser, "",
+        testTaskInstance
+                = new TaskInstance(testUser, "", testTask);
+        implTaskInstance = new TaskInstance(testUser, "",
                 implementationTask);
         testTask.setChallenge(challenge);
         challenge.addTask(implementationTask);
@@ -106,15 +103,15 @@ public class TaskControllerTest {
 
     @Test
     public void givenTaskWhenGetTestTask() throws Exception {
-        when(taskImplementationServiceMock.findOne(testTaskImplementation.getId()))
-                .thenReturn(testTaskImplementation);
-        Map<String, EditorTabData> tabData = this.generateTestTabData(implTaskImplementation, testTaskImplementation);
-        when(editorServiceMock.generateEditorContents(testTaskImplementation)).thenReturn(tabData);
-        String uri = "/task/"+testTaskImplementation.getId();
+        when(taskImplementationServiceMock.findOne(testTaskInstance.getId()))
+                .thenReturn(testTaskInstance);
+        Map<String, EditorTabData> tabData = this.generateTestTabData(implTaskInstance, testTaskInstance);
+        when(editorServiceMock.generateEditorContents(testTaskInstance)).thenReturn(tabData);
+        String uri = "/task/"+ testTaskInstance.getId();
         performSimpleGetRequestAndFindContent(uri, "task", testTask.getCodeStub());
-        verify(taskImplementationServiceMock, times(1)).findOne(testTaskImplementation.getId());
+        verify(taskImplementationServiceMock, times(1)).findOne(testTaskInstance.getId());
         verify(editorServiceMock, times(1))
-                .generateEditorContents(testTaskImplementation);
+                .generateEditorContents(testTaskInstance);
         verifyNoMoreInteractions(taskImplementationServiceMock);
         verifyNoMoreInteractions(editorServiceMock);
     }
@@ -123,36 +120,36 @@ public class TaskControllerTest {
     public void givenTaskWhenGetImplementationTask() throws Exception {
         User testUser = new User(1, "TESTUSER", 1);
 
-        when(taskImplementationServiceMock.findOne(implTaskImplementation.getId()))
-                .thenReturn(implTaskImplementation);
-        Map<String, EditorTabData> tabData = generateImplTabData(implTaskImplementation, testTaskImplementation);
-        when(editorServiceMock.generateEditorContents(implTaskImplementation)).thenReturn(tabData);
-        String uri = "/task/" + implTaskImplementation.getId();
+        when(taskImplementationServiceMock.findOne(implTaskInstance.getId()))
+                .thenReturn(implTaskInstance);
+        Map<String, EditorTabData> tabData = generateImplTabData(implTaskInstance, testTaskInstance);
+        when(editorServiceMock.generateEditorContents(implTaskInstance)).thenReturn(tabData);
+        String uri = "/task/" + implTaskInstance.getId();
         performSimpleGetRequestAndFindContent(uri, "task", implementationTask.getCodeStub());
-        verify(taskImplementationServiceMock, times(1)).findOne(implTaskImplementation.getId());
+        verify(taskImplementationServiceMock, times(1)).findOne(implTaskInstance.getId());
         verify(editorServiceMock, times(1))
-                .generateEditorContents(implTaskImplementation);
+                .generateEditorContents(implTaskInstance);
         verifyNoMoreInteractions(taskImplementationServiceMock);
         verifyNoMoreInteractions(editorServiceMock);
     }
     
-    private Map<String, EditorTabData> generateImplTabData(TaskImplementation implTaskImplementation,
-            TaskImplementation testTaskImplementation) {
+    private Map<String, EditorTabData> generateImplTabData(TaskInstance implTaskInstance,
+            TaskInstance testTaskInstance) {
         Map<String, EditorTabData> tabData = new LinkedHashMap<String, EditorTabData>();
         EditorTabData tab1 = new EditorTabData("Implement code here",
-                        implTaskImplementation.getTask().getCodeStub());
-        EditorTabData tab2 = new EditorTabData("Test to fulfill",testTaskImplementation.getTask().getCodeStub());
+                        implTaskInstance.getTask().getCodeStub());
+        EditorTabData tab2 = new EditorTabData("Test to fulfill", testTaskInstance.getTask().getCodeStub());
         tabData.put("editor1", tab1);
         tabData.put("editor2", tab2);
         return tabData;
     }
   
-    private Map<String, EditorTabData> generateTestTabData(TaskImplementation implTaskImplementation,
-            TaskImplementation testTaskImplementation) {
+    private Map<String, EditorTabData> generateTestTabData(TaskInstance implTaskInstance,
+            TaskInstance testTaskInstance) {
         Map<String, EditorTabData> tabData = new LinkedHashMap<String, EditorTabData>();
         EditorTabData tab1 = new EditorTabData("Implement code here",
-                implTaskImplementation.getTask().getCodeStub());
-        EditorTabData tab2 = new EditorTabData("Test to fulfill", testTaskImplementation.getTask().getCodeStub());
+                implTaskInstance.getTask().getCodeStub());
+        EditorTabData tab2 = new EditorTabData("Test to fulfill", testTaskInstance.getTask().getCodeStub());
         tabData.put("editor1", tab1);
         tabData.put("editor2", tab2);
         return tabData;
@@ -164,13 +161,13 @@ public class TaskControllerTest {
         String submissionCode = "/* this is an implementation */";
         String staticFileName = JavaClassGenerator.generateTestClassFilename(challenge);
         String staticCode = "/* this is a test */";
-        when(taskImplementationServiceMock.findOne(implTaskImplementation.getId())).thenReturn(implTaskImplementation);
+        when(taskImplementationServiceMock.findOne(implTaskInstance.getId())).thenReturn(implTaskInstance);
         when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
         when(taskServiceMock.findTaskInChallenge(challenge.getId(), testTask.getIndex())).thenReturn(testTask);
         mvc.perform(post("/task")
                 .param("submissionCode", submissionCode)
                 .param("staticCode", staticCode)
-                .param("taskImplementationId", Long.toString(implTaskImplementation.getId())))
+                .param("taskImplementationId", Long.toString(implTaskInstance.getId())))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("/feedback*"));
         verify(packagingService).packageSubmission(packagingArgCaptor.capture());
@@ -179,8 +176,8 @@ public class TaskControllerTest {
         assertArrayEquals(submissionCode.getBytes(), files.get(submissionFileName));
         assertArrayEquals(staticCode.getBytes(), files.get(staticFileName));
 
-        verify(taskImplementationServiceMock, times(1)).findOne(implTaskImplementation.getId());
-        verify(taskImplementationServiceMock).updateTaskImplementationCode(implTaskImplementation.getId(),
+        verify(taskImplementationServiceMock, times(1)).findOne(implTaskInstance.getId());
+        verify(taskImplementationServiceMock).updateTaskImplementationCode(implTaskInstance.getId(),
                                                                            submissionCode);
 
         verifyNoMoreInteractions(packagingService);

--- a/src/test/java/pingis/entities/TaskInstanceTest.java
+++ b/src/test/java/pingis/entities/TaskInstanceTest.java
@@ -17,7 +17,7 @@ public class TaskInstanceTest {
     public void setUp() {
         authorUser = new User(1, "ModelUser", TMC_USER_LEVEL);
         testTask = new Task(0,
-                ImplementationType.IMPLEMENTATION,
+                TaskType.IMPLEMENTATION,
                             authorUser,
                             "Test Addition",
                             "Test addition with two integers.",

--- a/src/test/java/pingis/entities/TaskInstanceTest.java
+++ b/src/test/java/pingis/entities/TaskInstanceTest.java
@@ -5,11 +5,11 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-public class TaskImplementationTest {
+public class TaskInstanceTest {
 
     private static final int TMC_USER_LEVEL = 100;
     
-    TaskImplementation userImplementation, protectedImplementation;
+    TaskInstance userImplementation, protectedImplementation;
     Task testTask;
     User authorUser;
     
@@ -25,12 +25,12 @@ public class TaskImplementationTest {
                             1,
                             0);
         
-        userImplementation = new TaskImplementation(
+        userImplementation = new TaskInstance(
                             authorUser, 
                             "return true;", 
                             testTask);
         
-        protectedImplementation = new TaskImplementation();
+        protectedImplementation = new TaskInstance();
     }
 
     @Test

--- a/src/test/java/pingis/entities/TaskTest.java
+++ b/src/test/java/pingis/entities/TaskTest.java
@@ -28,7 +28,7 @@ public class TaskTest {
     
     @Test
     public void testTaskImplementations() {
-        assertEquals(0, normalTask.getImplementations().size());
+        assertEquals(0, normalTask.getTaskInstances().size());
     }
 
     @Test

--- a/src/test/java/pingis/entities/TaskTest.java
+++ b/src/test/java/pingis/entities/TaskTest.java
@@ -27,7 +27,7 @@ public class TaskTest {
     }
     
     @Test
-    public void testTaskImplementations() {
+    public void testTaskInstances() {
         assertEquals(0, normalTask.getTaskInstances().size());
     }
 

--- a/src/test/java/pingis/entities/TaskTest.java
+++ b/src/test/java/pingis/entities/TaskTest.java
@@ -12,7 +12,7 @@ public class TaskTest {
 
     @Before
     public void setUp() {
-        normalTask = new Task(1, ImplementationType.TEST,
+        normalTask = new Task(1, TaskType.TEST,
                 new User(new Random().nextLong(), "Test_user", 1),
                 "tostring", 
                 "generate toString()",

--- a/src/test/java/pingis/services/DataImporterTest.java
+++ b/src/test/java/pingis/services/DataImporterTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import pingis.entities.Challenge;
 import pingis.entities.Task;
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import pingis.entities.User;
 import static pingis.services.DataImporter.UserType.TEST_USER;
 import static pingis.services.DataImporter.UserType.TMC_MODEL_USER;
@@ -64,11 +64,11 @@ public class DataImporterTest {
         HashMap<String, Challenge> challenges = importer.getChallenges();
 
         ArrayList<Task> tasks = importer.getTasks();
-        ArrayList<TaskImplementation> taskImplementations = importer.getTaskImplementations();
+        ArrayList<TaskInstance> taskInstances = importer.getTaskInstances();
 
         assertEquals(challenges.get("calculator").getName(), "calculator");
         assertEquals(tasks.get(0).getName(), "Test multiplication");
-        assertEquals(taskImplementations.get(0).getTask(), tasks.get(0));
+        assertEquals(taskInstances.get(0).getTask(), tasks.get(0));
     }
 
 }

--- a/src/test/java/pingis/services/EditorServiceTest.java
+++ b/src/test/java/pingis/services/EditorServiceTest.java
@@ -25,7 +25,7 @@ public class EditorServiceTest {
     @Autowired
     private EditorService editorService;
     @MockBean
-    private TaskImplementationService taskImplementationServiceMock;
+    private TaskInstanceService taskInstanceServiceMock;
     
     private User testUser;
     private Task testTask;
@@ -62,25 +62,25 @@ public class EditorServiceTest {
     
     @Test
     public void testEditorServiceWithTestTask() {
-        when(taskImplementationServiceMock.getCorrespondingImplTaskInstance(returnedTaskInstance))
+        when(taskInstanceServiceMock.getCorrespondingImplTaskInstance(returnedTaskInstance))
                 .thenReturn(this.passedTaskInstance);
         Map<String, EditorTabData> result = editorService.generateEditorContents(returnedTaskInstance);
         assertEquals(result.get("editor1").code, "public void test");
-        verify(taskImplementationServiceMock, times(1)).
+        verify(taskInstanceServiceMock, times(1)).
                 getCorrespondingImplTaskInstance(returnedTaskInstance);
-        verifyNoMoreInteractions(taskImplementationServiceMock);
+        verifyNoMoreInteractions(taskInstanceServiceMock);
     }
     
     @Test
     public void testEditorServiceWithImplementationTask() {
-        when(taskImplementationServiceMock.getCorrespondingTestTaskInstance(this.passedTaskInstance)).
+        when(taskInstanceServiceMock.getCorrespondingTestTaskInstance(this.passedTaskInstance)).
                 thenReturn(this.returnedTaskInstance);
         Map<String, EditorTabData> result = this.editorService.generateEditorContents(passedTaskInstance);
         assertEquals(result.get("editor2").code, "public void test");
         assertEquals(result.get("editor1").code, "public void implementation");
-        verify(taskImplementationServiceMock, times(1)).
+        verify(taskInstanceServiceMock, times(1)).
                 getCorrespondingTestTaskInstance(passedTaskInstance);
-        verifyNoMoreInteractions(taskImplementationServiceMock);
+        verifyNoMoreInteractions(taskInstanceServiceMock);
     }
 
 }

--- a/src/test/java/pingis/services/EditorServiceTest.java
+++ b/src/test/java/pingis/services/EditorServiceTest.java
@@ -3,8 +3,7 @@ package pingis.services;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-import pingis.entities.Task;
-import pingis.entities.User;
+import pingis.entities.*;
 
 import static org.mockito.Mockito.*;
 
@@ -15,9 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import pingis.Application;
-import pingis.entities.Challenge;
-import pingis.entities.ImplementationType;
-import pingis.entities.TaskImplementation;
+import pingis.entities.TaskInstance;
 import pingis.utils.EditorTabData;
 
 
@@ -34,8 +31,8 @@ public class EditorServiceTest {
     private Task testTask;
     private Task implementationTask;
     private Challenge challenge;
-    private TaskImplementation passedTaskImplementation;
-    private TaskImplementation returnedTaskImplementation;
+    private TaskInstance passedTaskInstance;
+    private TaskInstance returnedTaskInstance;
 
     @Before
     public void setUp() {
@@ -58,31 +55,31 @@ public class EditorServiceTest {
                 2, 2);
         testTask.setChallenge(challenge);
         implementationTask.setChallenge(challenge);
-        this.passedTaskImplementation = new TaskImplementation(testUser, "", implementationTask);
-        this.returnedTaskImplementation = new TaskImplementation(testUser, "public void test", testTask);
+        this.passedTaskInstance = new TaskInstance(testUser, "", implementationTask);
+        this.returnedTaskInstance = new TaskInstance(testUser, "public void test", testTask);
                 
     }
     
     @Test
     public void testEditorServiceWithTestTask() {
-        when(taskImplementationServiceMock.getCorrespondingImplTaskImplementation(returnedTaskImplementation))
-                .thenReturn(this.passedTaskImplementation);
-        Map<String, EditorTabData> result = editorService.generateEditorContents(returnedTaskImplementation);
+        when(taskImplementationServiceMock.getCorrespondingImplTaskInstance(returnedTaskInstance))
+                .thenReturn(this.passedTaskInstance);
+        Map<String, EditorTabData> result = editorService.generateEditorContents(returnedTaskInstance);
         assertEquals(result.get("editor1").code, "public void test");
         verify(taskImplementationServiceMock, times(1)).
-                getCorrespondingImplTaskImplementation(returnedTaskImplementation);
+                getCorrespondingImplTaskInstance(returnedTaskInstance);
         verifyNoMoreInteractions(taskImplementationServiceMock);
     }
     
     @Test
     public void testEditorServiceWithImplementationTask() {
-        when(taskImplementationServiceMock.getCorrespondingTestTaskImplementation(this.passedTaskImplementation)).
-                thenReturn(this.returnedTaskImplementation);
-        Map<String, EditorTabData> result = this.editorService.generateEditorContents(passedTaskImplementation);
+        when(taskImplementationServiceMock.getCorrespondingTestTaskInstance(this.passedTaskInstance)).
+                thenReturn(this.returnedTaskInstance);
+        Map<String, EditorTabData> result = this.editorService.generateEditorContents(passedTaskInstance);
         assertEquals(result.get("editor2").code, "public void test");
         assertEquals(result.get("editor1").code, "public void implementation");
         verify(taskImplementationServiceMock, times(1)).
-                getCorrespondingTestTaskImplementation(passedTaskImplementation);
+                getCorrespondingTestTaskInstance(passedTaskInstance);
         verifyNoMoreInteractions(taskImplementationServiceMock);
     }
 

--- a/src/test/java/pingis/services/EditorServiceTest.java
+++ b/src/test/java/pingis/services/EditorServiceTest.java
@@ -39,7 +39,7 @@ public class EditorServiceTest {
         this.challenge = new Challenge("testchallenge", testUser, "testing");
         this.testTask = new Task(
                 1,
-                ImplementationType.TEST,
+                TaskType.TEST,
                 testUser,
                 "test",
                 "testing",
@@ -47,7 +47,7 @@ public class EditorServiceTest {
                 1, 1);
         this.implementationTask = new Task(
                 2,
-                ImplementationType.IMPLEMENTATION,
+                TaskType.IMPLEMENTATION,
                 testUser,
                 "implementing",
                 "testing",

--- a/src/test/java/pingis/services/JavaClassGeneratorTest.java
+++ b/src/test/java/pingis/services/JavaClassGeneratorTest.java
@@ -1,7 +1,6 @@
 
 package pingis.services;
 
-import antlr.JavaCodeGenerator;
 import pingis.utils.JavaClassGenerator;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,7 @@ import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 import pingis.entities.Challenge;
 import pingis.entities.ChallengeType;
-import pingis.entities.ImplementationType;
+import pingis.entities.TaskType;
 import pingis.entities.Task;
 import pingis.entities.User;
 
@@ -35,17 +34,17 @@ public class JavaClassGeneratorTest {
 
         User testUser = new User(new Random().nextLong(), "Test_userfirst", Challenge1Level);
         
-        task1 = new Task(0, ImplementationType.TEST, testUser, "testAddition",
+        task1 = new Task(0, TaskType.TEST, testUser, "testAddition",
                 "test addition of two integers, return single value", 
                 "@Test\npublic void testAddition() {\n\t//TODO: implement this\n\n}", 
                 Challenge1Level, 0);
         
-        task2 = new Task(1, ImplementationType.TEST, testUser, "testSubstraction",
+        task2 = new Task(1, TaskType.TEST, testUser, "testSubstraction",
                 "test substraction of two integers, return single value", 
                 "@Test\npublic void testSubstraction() {\n\t//TODO: implement this\n\n}", 
                 Challenge1Level, 0);
         
-        task3 = new Task(2, ImplementationType.TEST, testUser, "testMultiplication",
+        task3 = new Task(2, TaskType.TEST, testUser, "testMultiplication",
                 "test multiplication of two integers, return single value", 
                 "@Test\npublic void testMultiplication() {\n\t//TODO: implement this\n\n}", 
                 Challenge1Level, 0);

--- a/src/test/java/pingis/services/TaskInstanceServiceTest.java
+++ b/src/test/java/pingis/services/TaskInstanceServiceTest.java
@@ -42,11 +42,11 @@ public class TaskInstanceServiceTest {
     @Before
     public void setUp() {
         testUser = new User(1l, "testUser", 1);
-        testTask = new Task(1, ImplementationType.TEST, testUser,
+        testTask = new Task(1, TaskType.TEST, testUser,
                 "Desc", "Desc", "Code",
                 1, 1);
         implementationTask = new Task(2,
-                ImplementationType.IMPLEMENTATION, testUser,
+                TaskType.IMPLEMENTATION, testUser,
                 "Desc", "Desc", "Code",
                 1, 1);
         testTaskInstance = new TaskInstance(testUser,

--- a/src/test/java/pingis/services/TaskInstanceServiceTest.java
+++ b/src/test/java/pingis/services/TaskInstanceServiceTest.java
@@ -63,7 +63,7 @@ public class TaskInstanceServiceTest {
     }
 
     @Test
-    public void getCorrespondingTestTaskImplementationTest() {
+    public void getCorrespondingTestTaskInstanceTest() {
         when(userRepositoryMock.findOne(0l)).thenReturn(testUser);
         when(taskRepositoryMock.findByIndexAndChallenge(implementationTask
                 .getIndex() - 1, testChallenge))
@@ -86,7 +86,7 @@ public class TaskInstanceServiceTest {
     }
 
     @Test
-    public void getCorrespondingImplementationTaskImplementationTest() {
+    public void getCorrespondingImplementationTaskInstanceTest() {
         when(userRepositoryMock.findOne(0l)).thenReturn(testUser);
         when(taskRepositoryMock.findByIndexAndChallenge(testTask.getIndex() + 1, testChallenge))
                 .thenReturn(implementationTask);
@@ -122,7 +122,7 @@ public class TaskInstanceServiceTest {
 
 
     @Test
-    public void testUpdateTaskImplementationCode() {
+    public void testUpdateTaskInstanceCode() {
         assertEquals("thisShouldBeEmpty", testTaskInstance.getCode());
 
         when(taskInstanceRepositoryMock.findOne(testTaskInstance.getId()))

--- a/src/test/java/pingis/services/TaskInstanceServiceTest.java
+++ b/src/test/java/pingis/services/TaskInstanceServiceTest.java
@@ -20,11 +20,11 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {TaskImplementationService.class})
+@ContextConfiguration(classes = {TaskInstanceService.class})
 public class TaskInstanceServiceTest {
 
     @Autowired
-    private TaskImplementationService taskImplementationService;
+    private TaskInstanceService taskInstanceService;
     @MockBean
     private TaskInstanceRepository taskInstanceRepositoryMock;
     @MockBean
@@ -71,7 +71,7 @@ public class TaskInstanceServiceTest {
         when(taskInstanceRepositoryMock.findByTaskAndUser(testTask, testUser))
                 .thenReturn(testTaskInstance);
 
-        TaskInstance result = taskImplementationService
+        TaskInstance result = taskInstanceService
                 .getCorrespondingTestTaskInstance(implementationTaskInstance);
 
         verify(userRepositoryMock).findOne(0l);
@@ -93,7 +93,7 @@ public class TaskInstanceServiceTest {
         when(taskInstanceRepositoryMock.findByTaskAndUser(implementationTask, testUser))
                 .thenReturn(implementationTaskInstance);
 
-        TaskInstance result = taskImplementationService
+        TaskInstance result = taskInstanceService
                 .getCorrespondingImplTaskInstance(testTaskInstance);
 
         verify(userRepositoryMock).findOne(0l);
@@ -112,7 +112,7 @@ public class TaskInstanceServiceTest {
         when(taskInstanceRepositoryMock.findOne(testTaskInstance.getId()))
                 .thenReturn(testTaskInstance);
 
-        TaskInstance result = taskImplementationService.findOne(testTaskInstance.getId());
+        TaskInstance result = taskInstanceService.findOne(testTaskInstance.getId());
 
         verify(taskInstanceRepositoryMock).findOne(testTaskInstance.getId());
         verifyNoMoreInteractions(taskInstanceRepositoryMock);
@@ -130,8 +130,8 @@ public class TaskInstanceServiceTest {
 
         String testCode = "Return 1+1;";
 
-        TaskInstance result = taskImplementationService
-                .updateTaskImplementationCode(testTaskInstance.getId(), testCode);
+        TaskInstance result = taskInstanceService
+                .updateTaskInstanceCode(testTaskInstance.getId(), testCode);
 
         verify(taskInstanceRepositoryMock).findOne(testTaskInstance.getId());
         verifyNoMoreInteractions(taskInstanceRepositoryMock);

--- a/src/test/java/pingis/services/TaskInstanceServiceTest.java
+++ b/src/test/java/pingis/services/TaskInstanceServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import pingis.entities.*;
-import pingis.repositories.TaskImplementationRepository;
+import pingis.repositories.TaskInstanceRepository;
 import pingis.repositories.TaskRepository;
 import pingis.repositories.UserRepository;
 
@@ -26,7 +26,7 @@ public class TaskInstanceServiceTest {
     @Autowired
     private TaskImplementationService taskImplementationService;
     @MockBean
-    private TaskImplementationRepository taskImplementationRepositoryMock;
+    private TaskInstanceRepository taskInstanceRepositoryMock;
     @MockBean
     private UserRepository userRepositoryMock;
     @MockBean
@@ -68,7 +68,7 @@ public class TaskInstanceServiceTest {
         when(taskRepositoryMock.findByIndexAndChallenge(implementationTask
                 .getIndex() - 1, testChallenge))
                 .thenReturn(testTask);
-        when(taskImplementationRepositoryMock.findByTaskAndUser(testTask, testUser))
+        when(taskInstanceRepositoryMock.findByTaskAndUser(testTask, testUser))
                 .thenReturn(testTaskInstance);
 
         TaskInstance result = taskImplementationService
@@ -76,11 +76,11 @@ public class TaskInstanceServiceTest {
 
         verify(userRepositoryMock).findOne(0l);
         verify(taskRepositoryMock).findByIndexAndChallenge(implementationTask.getIndex() - 1, testChallenge);
-        verify(taskImplementationRepositoryMock).findByTaskAndUser(testTask, testUser);
+        verify(taskInstanceRepositoryMock).findByTaskAndUser(testTask, testUser);
 
         verifyNoMoreInteractions(taskRepositoryMock);
         verifyNoMoreInteractions(userRepositoryMock);
-        verifyNoMoreInteractions(taskImplementationRepositoryMock);
+        verifyNoMoreInteractions(taskInstanceRepositoryMock);
 
         assertEquals(result, testTaskInstance);
     }
@@ -90,7 +90,7 @@ public class TaskInstanceServiceTest {
         when(userRepositoryMock.findOne(0l)).thenReturn(testUser);
         when(taskRepositoryMock.findByIndexAndChallenge(testTask.getIndex() + 1, testChallenge))
                 .thenReturn(implementationTask);
-        when(taskImplementationRepositoryMock.findByTaskAndUser(implementationTask, testUser))
+        when(taskInstanceRepositoryMock.findByTaskAndUser(implementationTask, testUser))
                 .thenReturn(implementationTaskInstance);
 
         TaskInstance result = taskImplementationService
@@ -98,24 +98,24 @@ public class TaskInstanceServiceTest {
 
         verify(userRepositoryMock).findOne(0l);
         verify(taskRepositoryMock).findByIndexAndChallenge(testTask.getIndex() + 1, testChallenge);
-        verify(taskImplementationRepositoryMock).findByTaskAndUser(implementationTask, testUser);
+        verify(taskInstanceRepositoryMock).findByTaskAndUser(implementationTask, testUser);
 
         verifyNoMoreInteractions(taskRepositoryMock);
         verifyNoMoreInteractions(userRepositoryMock);
-        verifyNoMoreInteractions(taskImplementationRepositoryMock);
+        verifyNoMoreInteractions(taskInstanceRepositoryMock);
 
         assertEquals(result, implementationTaskInstance);
     }
 
     @Test
     public void testFindOne() {
-        when(taskImplementationRepositoryMock.findOne(testTaskInstance.getId()))
+        when(taskInstanceRepositoryMock.findOne(testTaskInstance.getId()))
                 .thenReturn(testTaskInstance);
 
         TaskInstance result = taskImplementationService.findOne(testTaskInstance.getId());
 
-        verify(taskImplementationRepositoryMock).findOne(testTaskInstance.getId());
-        verifyNoMoreInteractions(taskImplementationRepositoryMock);
+        verify(taskInstanceRepositoryMock).findOne(testTaskInstance.getId());
+        verifyNoMoreInteractions(taskInstanceRepositoryMock);
 
         assertEquals(result, testTaskInstance);
     }
@@ -125,7 +125,7 @@ public class TaskInstanceServiceTest {
     public void testUpdateTaskImplementationCode() {
         assertEquals("thisShouldBeEmpty", testTaskInstance.getCode());
 
-        when(taskImplementationRepositoryMock.findOne(testTaskInstance.getId()))
+        when(taskInstanceRepositoryMock.findOne(testTaskInstance.getId()))
                 .thenReturn(testTaskInstance);
 
         String testCode = "Return 1+1;";
@@ -133,8 +133,8 @@ public class TaskInstanceServiceTest {
         TaskInstance result = taskImplementationService
                 .updateTaskImplementationCode(testTaskInstance.getId(), testCode);
 
-        verify(taskImplementationRepositoryMock).findOne(testTaskInstance.getId());
-        verifyNoMoreInteractions(taskImplementationRepositoryMock);
+        verify(taskInstanceRepositoryMock).findOne(testTaskInstance.getId());
+        verifyNoMoreInteractions(taskInstanceRepositoryMock);
 
         assertEquals(testCode, result.getCode());
     }

--- a/src/test/java/pingis/services/TaskInstanceServiceTest.java
+++ b/src/test/java/pingis/services/TaskInstanceServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {TaskImplementationService.class})
-public class TaskImplementationServiceTest {
+public class TaskInstanceServiceTest {
 
     @Autowired
     private TaskImplementationService taskImplementationService;
@@ -35,8 +35,8 @@ public class TaskImplementationServiceTest {
     private User testUser;
     private Task testTask;
     private Task implementationTask;
-    private TaskImplementation testTaskImplementation;
-    private TaskImplementation implementationTaskImplementation;
+    private TaskInstance testTaskInstance;
+    private TaskInstance implementationTaskInstance;
     private Challenge testChallenge;
 
     @Before
@@ -49,10 +49,10 @@ public class TaskImplementationServiceTest {
                 ImplementationType.IMPLEMENTATION, testUser,
                 "Desc", "Desc", "Code",
                 1, 1);
-        testTaskImplementation = new TaskImplementation(testUser,
+        testTaskInstance = new TaskInstance(testUser,
                 "thisShouldBeEmpty", testTask);
 
-        implementationTaskImplementation = new TaskImplementation(testUser,
+        implementationTaskInstance = new TaskInstance(testUser,
                 "return 'This is my implementation';", implementationTask);
         testChallenge = new Challenge("Name",
                 testUser, "Simple calculator", ChallengeType.MIXED);
@@ -69,10 +69,10 @@ public class TaskImplementationServiceTest {
                 .getIndex() - 1, testChallenge))
                 .thenReturn(testTask);
         when(taskImplementationRepositoryMock.findByTaskAndUser(testTask, testUser))
-                .thenReturn(testTaskImplementation);
+                .thenReturn(testTaskInstance);
 
-        TaskImplementation result = taskImplementationService
-                .getCorrespondingTestTaskImplementation(implementationTaskImplementation);
+        TaskInstance result = taskImplementationService
+                .getCorrespondingTestTaskInstance(implementationTaskInstance);
 
         verify(userRepositoryMock).findOne(0l);
         verify(taskRepositoryMock).findByIndexAndChallenge(implementationTask.getIndex() - 1, testChallenge);
@@ -82,7 +82,7 @@ public class TaskImplementationServiceTest {
         verifyNoMoreInteractions(userRepositoryMock);
         verifyNoMoreInteractions(taskImplementationRepositoryMock);
 
-        assertEquals(result, testTaskImplementation);
+        assertEquals(result, testTaskInstance);
     }
 
     @Test
@@ -91,10 +91,10 @@ public class TaskImplementationServiceTest {
         when(taskRepositoryMock.findByIndexAndChallenge(testTask.getIndex() + 1, testChallenge))
                 .thenReturn(implementationTask);
         when(taskImplementationRepositoryMock.findByTaskAndUser(implementationTask, testUser))
-                .thenReturn(implementationTaskImplementation);
+                .thenReturn(implementationTaskInstance);
 
-        TaskImplementation result = taskImplementationService
-                .getCorrespondingImplTaskImplementation(testTaskImplementation);
+        TaskInstance result = taskImplementationService
+                .getCorrespondingImplTaskInstance(testTaskInstance);
 
         verify(userRepositoryMock).findOne(0l);
         verify(taskRepositoryMock).findByIndexAndChallenge(testTask.getIndex() + 1, testChallenge);
@@ -104,36 +104,36 @@ public class TaskImplementationServiceTest {
         verifyNoMoreInteractions(userRepositoryMock);
         verifyNoMoreInteractions(taskImplementationRepositoryMock);
 
-        assertEquals(result, implementationTaskImplementation);
+        assertEquals(result, implementationTaskInstance);
     }
 
     @Test
     public void testFindOne() {
-        when(taskImplementationRepositoryMock.findOne(testTaskImplementation.getId()))
-                .thenReturn(testTaskImplementation);
+        when(taskImplementationRepositoryMock.findOne(testTaskInstance.getId()))
+                .thenReturn(testTaskInstance);
 
-        TaskImplementation result = taskImplementationService.findOne(testTaskImplementation.getId());
+        TaskInstance result = taskImplementationService.findOne(testTaskInstance.getId());
 
-        verify(taskImplementationRepositoryMock).findOne(testTaskImplementation.getId());
+        verify(taskImplementationRepositoryMock).findOne(testTaskInstance.getId());
         verifyNoMoreInteractions(taskImplementationRepositoryMock);
 
-        assertEquals(result, testTaskImplementation);
+        assertEquals(result, testTaskInstance);
     }
 
 
     @Test
     public void testUpdateTaskImplementationCode() {
-        assertEquals("thisShouldBeEmpty", testTaskImplementation.getCode());
+        assertEquals("thisShouldBeEmpty", testTaskInstance.getCode());
 
-        when(taskImplementationRepositoryMock.findOne(testTaskImplementation.getId()))
-                .thenReturn(testTaskImplementation);
+        when(taskImplementationRepositoryMock.findOne(testTaskInstance.getId()))
+                .thenReturn(testTaskInstance);
 
         String testCode = "Return 1+1;";
 
-        TaskImplementation result = taskImplementationService
-                .updateTaskImplementationCode(testTaskImplementation.getId(), testCode);
+        TaskInstance result = taskImplementationService
+                .updateTaskImplementationCode(testTaskInstance.getId(), testCode);
 
-        verify(taskImplementationRepositoryMock).findOne(testTaskImplementation.getId());
+        verify(taskImplementationRepositoryMock).findOne(testTaskInstance.getId());
         verifyNoMoreInteractions(taskImplementationRepositoryMock);
 
         assertEquals(testCode, result.getCode());

--- a/src/test/java/pingis/services/TaskServiceTest.java
+++ b/src/test/java/pingis/services/TaskServiceTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
-import pingis.entities.ImplementationType;
+import pingis.entities.TaskType;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {Application.class})
@@ -43,7 +43,7 @@ public class TaskServiceTest {
     @Before
     public void setUp() {
         testUser = new User(1, "Matti", 1);
-        testTask = new Task(1, ImplementationType.TEST, testUser, "FirstTask", "SimpleCalcluator", "return 0;", 1, 1);
+        testTask = new Task(1, TaskType.TEST, testUser, "FirstTask", "SimpleCalcluator", "return 0;", 1, 1);
         taskCaptor = ArgumentCaptor.forClass(Task.class);
     }
 


### PR DESCRIPTION
`ChallengeImplementation`, `TaskImplementation`, and `ImplementationType` are really confusing names and not that descriptive. 'Instance' is a better term for these, so they're renamed accordingly.

Some of these changes (e.g. replacing some imports with `import x.y.*`) are slightly unnecessary, but IntelliJ decided to do them without asking. ¯\\_(ツ)_/¯