### PR TITLE
Add forward-headers directive in application-prod

### DIFF
--- a/config/application-prod.yml
+++ b/config/application-prod.yml
@@ -7,3 +7,6 @@ security:
     client:
       tmc:
         redirectUri: https://pingis.testmycode.io/oauth2/authorize/code/tmc
+
+server:
+  use-forward-headers: true


### PR DESCRIPTION
The reverse proxy (nginx) running on the server forwarded the request to the correct redirect-uri (https://pingis.testmycode.io/oauth2/authorize/code/tmc). Alas, Spring Boot does not automatically forward the headers containing information on the request to the application, including the redirect-uri. Since the app failed to match the redirect-uri from the request with the one set in the property files, the login failed.