### PR TITLE
Make static classpath resources reloadable.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ bootRun {
         environment 'TMC_SECRET', TMC_SECRET
     }
 	systemProperties System.properties
+
+    // Make static classpath resources reloadable when using bootRun
+    addResources = true
 }
 
 


### PR DESCRIPTION
This skips preprocessing for resources (under `src/main/resources`), so they can be reloaded live when running with `gradle bootRun`. Especially helpful for working with templates, as there's no need to restart the application after making a change.