### PR TITLE
Feedback directed to the proper user

### DIFF
--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -101,7 +101,6 @@ public class TaskController {
     Task currentTask = taskInstance.getTask();
 
     Challenge currentChallenge = currentTask.getChallenge();
-    redirectAttributes.addAttribute("taskInstanceId", taskInstanceId);
 
     String[] errors = checkErrors(submissionCode, staticCode);
     if (errors != null) {
@@ -112,7 +111,7 @@ public class TaskController {
 
     TmcSubmission submission = submitToTmc(taskInstance, currentChallenge, submissionCode,
         staticCode);
-    redirectAttributes.addAttribute("submission", submission);
+    redirectAttributes.addAttribute("submissionId", submission.getId());
 
     // Save user's answer from left editor
     taskInstanceService.updateTaskInstanceCode(taskInstanceId, submissionCode);
@@ -121,12 +120,8 @@ public class TaskController {
   }
 
   @RequestMapping("/feedback")
-  public String feedback(Model model, @RequestParam long taskInstanceId) {
-    Challenge currentChallenge = taskInstanceService
-        .findOne(taskInstanceId)
-        .getTask().getChallenge();
-    model.addAttribute("challengeId", currentChallenge.getId());
-    model.addAttribute("feedback", "Good work!");
+  public String feedback(Model model, @RequestParam String submissionId) {
+    model.addAttribute("submissionId", submissionId);
     return "feedback";
   }
 

--- a/src/main/java/pingis/controllers/TmcSubmissionController.java
+++ b/src/main/java/pingis/controllers/TmcSubmissionController.java
@@ -79,7 +79,7 @@ public class TmcSubmissionController {
       taskInstanceService.markAsDone(submission.getTaskInstance());
     }
     //Broadcasts the submission to /topic/results
-    this.template.convertAndSend("/topic/results", message);
+    this.template.convertAndSend("/topic/results/" + submission.getId(), message);
     logger.debug("Sent the TMC sandbox results to /topic/results");
   }
 

--- a/src/main/resources/static/js/feedbackStomp.js
+++ b/src/main/resources/static/js/feedbackStomp.js
@@ -17,6 +17,6 @@ function connectStomp(csrf) {
 
     stompClient = Stomp.over(new SockJS('/websocket'));
     stompClient.connect(headers, function () {
-        stompClient.subscribe('/topic/results', showResults);
+        stompClient.subscribe('/topic/results/' + submissionId, showResults);
     });
 }

--- a/src/main/resources/templates/feedback.html
+++ b/src/main/resources/templates/feedback.html
@@ -23,6 +23,12 @@
             <script th:src="@{/webjars/stomp-websocket/stomp.min.js}"></script>
             <script th:src="@{/js/results.js}"></script>
             <script th:src="@{/js/feedbackStomp.js}"></script>
+            <script th:inline="javascript">
+            /*<![CDATA[*/
+                //Makes the model attribute usable in external javascript files
+                var submissionId = /*[[${submissionId}]]*/;
+            /*]]>*/
+            </script>
         </div>
     </body>
 </html>

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -15,11 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,6 +38,7 @@ import pingis.entities.Task;
 import pingis.entities.TaskInstance;
 import pingis.entities.TaskType;
 import pingis.entities.User;
+import pingis.entities.tmc.TmcSubmission;
 import pingis.services.ChallengeService;
 import pingis.services.EditorService;
 import pingis.services.SubmissionPackagingService;
@@ -88,6 +91,7 @@ public class TaskControllerTest {
   private TaskInstance testTaskInstance;
   private TaskInstance implTaskInstance;
   private User testUser;
+  private TmcSubmission submission;
 
   @Before
   public void setUp() {
@@ -107,6 +111,8 @@ public class TaskControllerTest {
     testTask.setChallenge(challenge);
     challenge.addTask(implementationTask);
     implementationTask.setChallenge(challenge);
+    submission = new TmcSubmission();
+    submission.setId(UUID.randomUUID());
     MockitoAnnotations.initMocks(this);
 
     this.mvc = MockMvcBuilders
@@ -169,6 +175,7 @@ public class TaskControllerTest {
     when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
     when(taskServiceMock.findTaskInChallenge(challenge.getId(), testTask.getIndex()))
         .thenReturn(testTask);
+    when(senderService.sendSubmission(Mockito.any(), Mockito.any())).thenReturn(submission);
     mvc.perform(post("/task")
         .param("submissionCode", submissionCode)
         .param("staticCode", staticCode)
@@ -192,16 +199,6 @@ public class TaskControllerTest {
     verifyNoMoreInteractions(challengeServiceMock);
     verifyNoMoreInteractions(taskServiceMock);
   }
-
-  @Test
-  public void givenFeedbackWhenGetFeedback() throws Exception {
-    when(taskInstanceServiceMock.findOne(1L)).thenReturn(testTaskInstance);
-    performSimpleGetRequestAndFindContent("/feedback?taskInstanceId=1", "feedback",
-        "<h1>Feedback</h1>");
-    verify(taskInstanceServiceMock).findOne(1L);
-    verifyNoMoreInteractions(taskInstanceServiceMock);
-  }
-
 
   private void performSimpleGetRequestAndFindContent(String uri,
       String viewName,


### PR DESCRIPTION
Feedback is now directed to the proper user using the submission id. I also removed unnecessary attributes from the feedback page as they were not used. A related test was removed as unnecessary, and one other modified so that a mock returns a proper submission object with an id.