### PR TITLE
Redirect to dashboard after login

### DIFF
--- a/src/main/java/pingis/controllers/IndexController.java
+++ b/src/main/java/pingis/controllers/IndexController.java
@@ -1,13 +1,19 @@
 package pingis.controllers;
 
+import java.security.Principal;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import pingis.services.UserService;
 
 @Controller
 public class IndexController {
-
+  
   @RequestMapping("/")
-  public String index() {
+  public String index(Principal principal) {
+    if (principal != null) { // Check if SecurityContext is populated with authenticated principal
+      return "redirect:/user";
+    }
     return "index";
   }
 }

--- a/src/test/java/pingis/controllers/UserDevControllerTest.java
+++ b/src/test/java/pingis/controllers/UserDevControllerTest.java
@@ -35,7 +35,7 @@ import pingis.services.UserService;
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest(UserDevController.class)
 @ContextConfiguration(classes = {UserDevController.class, SecurityDevConfig.class, 
-                                 UserService.class})
+                                 UserService.class, IndexController.class})
 @WebAppConfiguration
 public class UserDevControllerTest {
 
@@ -114,5 +114,20 @@ public class UserDevControllerTest {
     mvc.perform(formLogin().user("user"))
             .andExpect(authenticated().withRoles("USER"))
             .andExpect(status().is3xxRedirection());
+  }
+  
+  @Test
+  public void testGivenPrincipalIsAuthenticatedIndexRedirectsToUser() throws Exception {
+    // Expected outcomes
+    String testUrl = "/";
+    String expectedContent = "Available challenges";
+    String expectedViewName = "redirect:/user";
+    
+    MvcResult result = mvc.perform(get(testUrl).with(securityContext(
+            mockContext.createSecurityContext(testUser))))
+            .andExpect(view().name(expectedViewName))
+            .andReturn();
+    
+    Mockito.verifyNoMoreInteractions(userServiceMock);
   }
 }

--- a/src/test/java/pingis/cucumber/Stepdefs.java
+++ b/src/test/java/pingis/cucumber/Stepdefs.java
@@ -145,7 +145,6 @@ public class Stepdefs {
     driver.quit();
   }
 
-
   private Map<String, String> initializeIds() {
     Map<String, String> map = new HashMap<>();
 
@@ -154,6 +153,7 @@ public class Stepdefs {
     map.put("My Account", "account-button");
     map.put("Log in", "log-in-button");
     map.put("Logout", "logout-button");
+    map.put("user page", "user");
     map.put("front page", "");
     map.put("login error page", "login?error");
     map.put("username field", "session_login");

--- a/src/test/resources/pingis/cucumber/login.feature
+++ b/src/test/resources/pingis/cucumber/login.feature
@@ -6,7 +6,7 @@ Scenario Outline: <user> can log in with valid username and password
     And inputs their username <username> and password <password>
     And clicks the Log in button
     Then <user> is successfully authenticated
-    And is redirected to the front page
+    And is redirected to the user page
 
     Examples:
         |user   |username   |password   |
@@ -40,4 +40,4 @@ Scenario: User can authenticate through TMC
     And inputs their TMC username and password
     And clicks Sign in
     Then user is successfully authenticated
-    And is redirected to the front page
+    And is redirected to the user page


### PR DESCRIPTION
Implemented:
* After login, authenticated user is redirected to `pingis.testmycode.io/user`
* all authenticated GET requests for "pingis.testmycode.io" redirect to `pingis.testmycode.io/user`
* fixed cucumber-tests