### PR TITLE
Speed up unit tests

### DIFF
--- a/src/test/java/pingis/controllers/IndexControllerTest.java
+++ b/src/test/java/pingis/controllers/IndexControllerTest.java
@@ -13,11 +13,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import pingis.Application;
 import pingis.config.SecurityDevConfig;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class, IndexController.class, SecurityDevConfig.class})
+@ContextConfiguration(classes = {IndexController.class, SecurityDevConfig.class})
 @WebAppConfiguration
 @WebMvcTest(IndexController.class)
 public class IndexControllerTest {

--- a/src/test/java/pingis/services/ChallengeServiceTest.java
+++ b/src/test/java/pingis/services/ChallengeServiceTest.java
@@ -24,7 +24,7 @@ import pingis.entities.User;
 import pingis.repositories.ChallengeRepository;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = {ChallengeService.class})
 public class ChallengeServiceTest {
 
   @Autowired

--- a/src/test/java/pingis/services/EditorServiceTest.java
+++ b/src/test/java/pingis/services/EditorServiceTest.java
@@ -23,7 +23,7 @@ import pingis.utils.EditorTabData;
 
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = {EditorService.class})
 public class EditorServiceTest {
 
   @Autowired

--- a/src/test/java/pingis/services/TaskServiceTest.java
+++ b/src/test/java/pingis/services/TaskServiceTest.java
@@ -20,20 +20,25 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import pingis.Application;
 import pingis.entities.Task;
+import pingis.entities.TaskInstance;
 import pingis.entities.TaskType;
 import pingis.entities.User;
 import pingis.repositories.ChallengeRepository;
+import pingis.repositories.TaskInstanceRepository;
 import pingis.repositories.TaskRepository;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = {TaskService.class})
 public class TaskServiceTest {
 
-  @Autowired
-  private TaskService taskService;
+  @MockBean
+  private TaskInstanceRepository taskInstanceRepository;
 
   @MockBean
   private TaskRepository taskRepositoryMock;
+
+  @Autowired
+  private TaskService taskService;
 
   @MockBean
   private ChallengeRepository challengeRepositoryMock;

--- a/src/test/java/pingis/services/UserServiceTest.java
+++ b/src/test/java/pingis/services/UserServiceTest.java
@@ -26,7 +26,7 @@ import pingis.entities.User;
 import pingis.repositories.UserRepository;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {Application.class})
+@ContextConfiguration(classes = {UserService.class})
 public class UserServiceTest {
 
   private static final int TEST_USER_ID = 1;


### PR DESCRIPTION
Initializing the full Spring application context in a test case is super slow. SUPER slow. See the benchmarks:

Before:
```
gradle clean unittest  2.29s user 0.16s system 6% cpu 37.908 total
gradle clean unittest  2.37s user 0.11s system 6% cpu 37.886 total
gradle clean unittest  2.32s user 0.11s system 6% cpu 36.785 total
```
Average test time: 37.526

After:
```
gradle clean unittest  2.30s user 0.17s system 10% cpu 23.907 total
gradle clean unittest  2.20s user 0.09s system 9% cpu 24.326 total
gradle clean unittest  2.20s user 0.11s system 9% cpu 23.806 total
```
Average test time: 24.013

The only thing done here was replacing Application.class in ContextConfiguration with more appropriate ones.