### PR TITLE
Don't send staticCode to server.

### DIFF
--- a/src/main/resources/templates/task.html
+++ b/src/main/resources/templates/task.html
@@ -52,7 +52,6 @@
                         </div>
                         <div class="panel-body">
                             <div id="static-editor" style="height: 300px" class="editortab" th:text="${staticCode}"></div>
-                            <textarea name="staticCode" id="static-code" style="display: none;" th:text="${staticCode}"/>
                         </div>
                     </div>
                     <button type="submit" class="btn btn-primary" onclick="clicked(event)">Submit</button>

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -166,18 +166,42 @@ public class TaskControllerTest {
   }
 
   @Test
-  public void submitTask() throws Exception {
+  public void submitTestTask() throws Exception {
+    String submissionCode = "/* this is a test */";
+
+    when(taskInstanceServiceMock.findOne(testTaskInstance.getId())).thenReturn(testTaskInstance);
+    when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
+    when(taskServiceMock.findTaskInChallenge(challenge.getId(), implementationTask.getIndex()))
+        .thenReturn(implementationTask);
+    when(taskServiceMock.getCorrespondingTask(testTask)).thenReturn(implementationTask);
+    when(sandboxServiceMock.submit(Mockito.any(), Mockito.any())).thenReturn(submission);
+    mvc.perform(post("/task")
+        .param("submissionCode", submissionCode)
+        .param("taskInstanceId", Long.toString(implTaskInstance.getId())))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrlPattern("/feedback*"));
+
+    verify(taskInstanceServiceMock, times(1)).findOne(testTaskInstance.getId());
+    verify(taskInstanceServiceMock).updateTaskInstanceCode(testTaskInstance.getId(),
+        submissionCode);
+    verify(taskServiceMock).getCorrespondingTask(testTask);
+    verifyNoMoreInteractions(taskInstanceServiceMock);
+    verifyNoMoreInteractions(challengeServiceMock);
+    verifyNoMoreInteractions(taskServiceMock);
+  }
+
+  @Test
+  public void submitImplementationTask() throws Exception {
     String submissionCode = "/* this is an implementation */";
-    String staticCode = "/* this is a test */";
 
     when(taskInstanceServiceMock.findOne(implTaskInstance.getId())).thenReturn(implTaskInstance);
     when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
     when(taskServiceMock.findTaskInChallenge(challenge.getId(), testTask.getIndex()))
         .thenReturn(testTask);
+    when(taskServiceMock.getCorrespondingTask(implementationTask)).thenReturn(testTask);
     when(sandboxServiceMock.submit(Mockito.any(), Mockito.any())).thenReturn(submission);
     mvc.perform(post("/task")
         .param("submissionCode", submissionCode)
-        .param("staticCode", staticCode)
         .param("taskInstanceId", Long.toString(implTaskInstance.getId())))
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrlPattern("/feedback*"));
@@ -185,6 +209,7 @@ public class TaskControllerTest {
     verify(taskInstanceServiceMock, times(1)).findOne(implTaskInstance.getId());
     verify(taskInstanceServiceMock).updateTaskInstanceCode(implTaskInstance.getId(),
         submissionCode);
+    verify(taskServiceMock).getCorrespondingTask(implementationTask);
     verifyNoMoreInteractions(taskInstanceServiceMock);
     verifyNoMoreInteractions(challengeServiceMock);
     verifyNoMoreInteractions(taskServiceMock);

--- a/src/test/resources/pingis/cucumber/editor_tabs.feature
+++ b/src/test/resources/pingis/cucumber/editor_tabs.feature
@@ -10,7 +10,7 @@ Feature: Content check for multiple editor tabs
 
       |user   |tab_name                 |content                               |page          |
       |User   |test/CalculatorTest.java |public void testMultiplication        |task/1        |
-      |User   |test/CalculatorTest.java |public class CalculatorTest           |task/2        |
-      |Admin  |src/Calculator.java      |public int add                       |task/3        |
+      |User   |test/CalculatorTest.java |CalculatorTest                        |task/2        |
+      |Admin  |src/Calculator.java      |add                                   |task/3        |
 
 


### PR DESCRIPTION
Even though the static code editor is set read-only, the user can still modify the code client-side and send it to the server (bad). We now have the necessary infrastructure in place to get the corresponding code for a task, so it's high time to remove it.