### PR TITLE
Fix SockJS exceptions

### DIFF
--- a/src/main/java/pingis/config/WebSocketSecurityConfig.java
+++ b/src/main/java/pingis/config/WebSocketSecurityConfig.java
@@ -1,10 +1,15 @@
 package pingis.config;
 
+import org.eclipse.jetty.websocket.api.WebSocketBehavior;
+import org.eclipse.jetty.websocket.api.WebSocketPolicy;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.server.jetty.JettyRequestUpgradeStrategy;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -15,8 +20,19 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
     config.enableSimpleBroker("/topic");
   }
 
+  @Bean
+  public DefaultHandshakeHandler handshakeHandler() {
+    WebSocketPolicy policy = new WebSocketPolicy(WebSocketBehavior.SERVER);
+    policy.setInputBufferSize(8192);
+    policy.setIdleTimeout(600000);
+
+    return new DefaultHandshakeHandler(new JettyRequestUpgradeStrategy(policy));
+  }
+
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/websocket").withSockJS();
+    registry.addEndpoint("/websocket")
+        .setHandshakeHandler(handshakeHandler())
+        .withSockJS();
   }
 }

--- a/src/main/java/pingis/config/WebSocketSecurityConfig.java
+++ b/src/main/java/pingis/config/WebSocketSecurityConfig.java
@@ -2,18 +2,24 @@ package pingis.config;
 
 import org.eclipse.jetty.websocket.api.WebSocketBehavior;
 import org.eclipse.jetty.websocket.api.WebSocketPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.StompWebSocketEndpointRegistration;
 import org.springframework.web.socket.server.jetty.JettyRequestUpgradeStrategy;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
+
+  @Autowired
+  private ApplicationContext applicationContext;
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -31,8 +37,15 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/websocket")
-        .setHandshakeHandler(handshakeHandler())
-        .withSockJS();
+    StompWebSocketEndpointRegistration endpointRegistration = registry
+        .addEndpoint("/websocket");
+
+    // HACK: Can't use JettyRequestUpgradeStrategy when running cucumber tests, because
+    // Jetty isn't running.
+    if (applicationContext.getEnvironment().getProperty("RUNNING_CUCUMBER") == null) {
+      endpointRegistration.setHandshakeHandler(handshakeHandler());
+    }
+
+    endpointRegistration.withSockJS();
   }
 }

--- a/src/test/java/pingis/controllers/TmcSubmissionControllerTest.java
+++ b/src/test/java/pingis/controllers/TmcSubmissionControllerTest.java
@@ -32,7 +32,6 @@ import org.springframework.web.context.WebApplicationContext;
 import pingis.Application;
 import pingis.config.OAuthProperties;
 import pingis.config.SecurityConfig;
-import pingis.config.WebSocketSecurityConfig;
 import pingis.entities.Task;
 import pingis.entities.TaskInstance;
 import pingis.entities.sandbox.Logs;
@@ -48,8 +47,7 @@ import pingis.services.sandbox.SandboxService;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes =
-    {Application.class, TmcSubmissionController.class, SecurityConfig.class, OAuthProperties.class,
-        WebSocketSecurityConfig.class})
+    {Application.class, TmcSubmissionController.class, SecurityConfig.class, OAuthProperties.class})
 @DirtiesContext
 @WebAppConfiguration
 @WebMvcTest(TmcSubmissionController.class)

--- a/src/test/java/pingis/cucumber/RunCukesTest.java
+++ b/src/test/java/pingis/cucumber/RunCukesTest.java
@@ -20,6 +20,7 @@ public class RunCukesTest {
     @Override
     protected void before() throws Throwable {
       this.app = SpringApplication.run(Application.class);
+      app.getEnvironment().getSystemEnvironment().put("RUNNING_CUCUMBER", "TRUE");
     }
 
     @Override


### PR DESCRIPTION
Adding a WebSocket handshake handler that explicitly uses Jetty fixes the issue with failed casts between ServletContext types.