### PR TITLE
Fake sandbox tests

### DIFF
--- a/src/main/java/pingis/controllers/FakeSandboxController.java
+++ b/src/main/java/pingis/controllers/FakeSandboxController.java
@@ -1,30 +1,15 @@
 package pingis.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.client.RestTemplate;
-import pingis.entities.TaskType;
-import pingis.entities.sandbox.ResultStatus;
-import pingis.entities.sandbox.Submission;
-import pingis.entities.sandbox.SubmissionStatus;
-import pingis.entities.sandbox.TestOutput;
-import pingis.repositories.sandbox.SubmissionRepository;
+import pingis.services.sandbox.FakeSandboxRestService;
 import pingis.services.sandbox.SubmissionResponse;
 
 /**
@@ -38,8 +23,8 @@ public class FakeSandboxController {
   private Logger logger = LoggerFactory.getLogger(this.getClass());
   
   @Autowired
-  private SubmissionRepository submissionRepository;
-
+  private FakeSandboxRestService fakeSandboxRestService;
+  
   @RequestMapping("/tasks.json")
   public ResponseEntity tasks(
         @RequestParam("token") String token,
@@ -47,78 +32,18 @@ public class FakeSandboxController {
     
     //NOTE: Making STOMP messages persist makes this obsolete
     try {
-      Thread.sleep(1000);
+      Thread.sleep(2000);
     } catch (InterruptedException ex) {
       logger.error("Sandbox thread stopped unexpectedly");
     }
 
     logger.debug("TOKEN::::::" + token);
     logger.debug("NOTIFY:::::" + notify);
-
-    RestTemplate restTemplate = new RestTemplate();
-
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-    HttpEntity<MultiValueMap<String, String>> request = buildResponseEntity(
-          generateSubmission(token), headers);
-
-    restTemplate.postForLocation(notify, request, String.class);
-
+    
+    fakeSandboxRestService.postSubmissionResults(token, notify);
+    
     SubmissionResponse sr = new SubmissionResponse();
     sr.setStatus("ok");
     return ResponseEntity.status(HttpStatus.OK).body(sr);
-  }
-
-  // TODO: Encapsulate this behaviour in a service
-  private Submission generateSubmission(String token) {
-    Submission submission = submissionRepository.findById(UUID.fromString(token)).get();
-
-    submission.setId(UUID.fromString(token));
-    submission.setStatus(SubmissionStatus.PENDING);
-    submission.setExitCode(0);
-    submission.setStderr("");
-    submission.setStdout("");
-
-    TaskType type = submission.getTaskInstance().getTask().getType();
-    ResultStatus resultStatus
-          = (type == TaskType.IMPLEMENTATION) ? ResultStatus.PASSED : ResultStatus.TESTS_FAILED;
-
-    try {
-      submission.setTestOutput(new ObjectMapper().readValue(
-            "{\"status\":\"" + resultStatus + "\","
-            + "\"testResults\":[],"
-            + "\"logs\":{"
-            + "\"stdout\":[0],"
-            + "\"stderr\":[0]"
-            + "}"
-            + "}", TestOutput.class));
-    } catch (IOException ex) {
-      logger.debug("JSON serialization failed");
-    }
-    submission.setValidations("");
-    submission.setVmLog("");
-
-    return submission;
-  }
-
-  private HttpEntity<MultiValueMap<String, String>> buildResponseEntity(
-        Submission submission, HttpHeaders headers) {
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-
-    try {
-      map.add("test_output", new ObjectMapper().writeValueAsString(
-            submission.getTestOutput()));
-    } catch (JsonProcessingException ex) {
-      logger.debug("POJO deserialization failed");
-    }
-    map.add("stdout", submission.getStdout());
-    map.add("stderr", submission.getStderr());
-    map.add("validations", submission.getValidations());
-    map.add("vm_log", submission.getVmLog());
-    map.add("token", submission.getId().toString());
-    map.add("status", submission.getStatus().toString());
-    map.add("exit_code", submission.getExitCode().toString());
-
-    return new HttpEntity<>(map, headers);
   }
 }

--- a/src/main/java/pingis/services/sandbox/FakeSandboxRestService.java
+++ b/src/main/java/pingis/services/sandbox/FakeSandboxRestService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -32,10 +33,16 @@ public class FakeSandboxRestService {
 
   private Logger logger = LoggerFactory.getLogger(this.getClass());
   
-  private RestTemplate restTemplate = new RestTemplate();
+  private RestTemplate restTemplate;
 
-  @Autowired
   private SubmissionRepository submissionRepository;
+  
+  @Autowired
+  public FakeSandboxRestService(RestTemplateBuilder restTemplateBuilder,
+      SubmissionRepository submissionRepository) {
+    this.submissionRepository = submissionRepository;
+    this.restTemplate = restTemplateBuilder.build();
+  }
 
   public void postSubmissionResults(String token, String notify) {
     HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/pingis/services/sandbox/FakeSandboxRestService.java
+++ b/src/main/java/pingis/services/sandbox/FakeSandboxRestService.java
@@ -1,0 +1,100 @@
+package pingis.services.sandbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import pingis.entities.TaskType;
+import pingis.entities.sandbox.ResultStatus;
+import pingis.entities.sandbox.Submission;
+import pingis.entities.sandbox.SubmissionStatus;
+import pingis.entities.sandbox.TestOutput;
+import pingis.repositories.sandbox.SubmissionRepository;
+
+/**
+ *
+ * @author juicyp
+ */
+@Service
+@Profile("dev")
+public class FakeSandboxRestService {
+
+  private Logger logger = LoggerFactory.getLogger(this.getClass());
+  
+  private RestTemplate restTemplate = new RestTemplate();
+
+  @Autowired
+  private SubmissionRepository submissionRepository;
+
+  public void postSubmissionResults(String token, String notify) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    HttpEntity<MultiValueMap<String, String>> request = buildResponseEntity(
+        generateSubmission(token), headers);
+
+    restTemplate.postForLocation(notify, request, String.class);
+  }
+
+  private Submission generateSubmission(String token) {
+    Submission submission = submissionRepository.findById(UUID.fromString(token)).get();
+
+    submission.setId(UUID.fromString(token));
+    submission.setStatus(SubmissionStatus.PENDING);
+    submission.setExitCode(0);
+    submission.setStderr("");
+    submission.setStdout("");
+
+    TaskType type = submission.getTaskInstance().getTask().getType();
+    ResultStatus resultStatus
+        = (type == TaskType.IMPLEMENTATION) ? ResultStatus.PASSED : ResultStatus.TESTS_FAILED;
+
+    try {
+      submission.setTestOutput(new ObjectMapper().readValue(
+          "{\"status\":\"" + resultStatus + "\","
+          + "\"testResults\":[],"
+          + "\"logs\":{"
+          + "\"stdout\":[0],"
+          + "\"stderr\":[0]"
+          + "}"
+          + "}", TestOutput.class));
+    } catch (IOException ex) {
+      logger.debug("JSON serialization failed");
+    }
+    submission.setValidations("");
+    submission.setVmLog("");
+
+    return submission;
+  }
+
+  private HttpEntity<MultiValueMap<String, String>> buildResponseEntity(
+      Submission submission, HttpHeaders headers) {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+
+    try {
+      map.add("test_output", new ObjectMapper().writeValueAsString(
+          submission.getTestOutput()));
+    } catch (JsonProcessingException ex) {
+      logger.debug("POJO deserialization failed");
+    }
+    map.add("stdout", submission.getStdout());
+    map.add("stderr", submission.getStderr());
+    map.add("validations", submission.getValidations());
+    map.add("vm_log", submission.getVmLog());
+    map.add("token", submission.getId().toString());
+    map.add("status", submission.getStatus().toString());
+    map.add("exit_code", submission.getExitCode().toString());
+
+    return new HttpEntity<>(map, headers);
+  }
+}

--- a/src/main/java/pingis/services/sandbox/StubSubmissionPackagingService.java
+++ b/src/main/java/pingis/services/sandbox/StubSubmissionPackagingService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @Profile("dev")
-public class MockSubmissionPackagingService implements SubmissionPackagingServiceInterface {
+public class StubSubmissionPackagingService implements SubmissionPackagingServiceInterface {
 
   @Override
   public byte[] packageSubmission(Map<String, byte[]> additionalFiles)

--- a/src/main/java/pingis/services/sandbox/SubmissionPackagingServiceStub.java
+++ b/src/main/java/pingis/services/sandbox/SubmissionPackagingServiceStub.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @Profile("dev")
-public class StubSubmissionPackagingService implements SubmissionPackagingServiceInterface {
+public class SubmissionPackagingServiceStub implements SubmissionPackagingServiceInterface {
 
   @Override
   public byte[] packageSubmission(Map<String, byte[]> additionalFiles)

--- a/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
+++ b/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
@@ -1,9 +1,9 @@
 package pingis.controllers;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.UUID;
 import org.junit.Test;
@@ -25,27 +25,27 @@ import pingis.services.sandbox.FakeSandboxRestService;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {
-  FakeSandboxController.class, SecurityConfig.class, OAuthProperties.class})
+    FakeSandboxController.class, SecurityConfig.class, OAuthProperties.class})
 @WebAppConfiguration
 @WebMvcTest(FakeSandboxController.class)
 public class FakeSandboxControllerTest {
-  
+
   @Autowired
   private MockMvc mvc;
-  
+
   @MockBean
   private FakeSandboxRestService fakeSandboxMock;
-  
+
   @Test
   public void resultStatusFailedWhenTestTaskInSubmission() throws Exception {
     UUID uuid = UUID.randomUUID();
     String url = "localhost";
-    
+
     mvc.perform(post("/tasks.json")
         .param("token", uuid.toString())
         .param("notify", url))
         .andExpect(status().isOk());
-    
+
     verify(fakeSandboxMock).postSubmissionResults(eq(uuid.toString()), eq(url));
   }
 }

--- a/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
+++ b/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
@@ -1,0 +1,70 @@
+package pingis.controllers;
+
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Matchers.eq;
+
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.verify;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import pingis.config.OAuthProperties;
+import pingis.config.SecurityConfig;
+import pingis.services.sandbox.FakeSandboxRestService;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ *
+ * @author juicyp
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {
+  FakeSandboxController.class, SecurityConfig.class, OAuthProperties.class})
+@WebAppConfiguration
+@WebMvcTest(FakeSandboxController.class)
+public class FakeSandboxControllerTest {
+  
+  @Autowired
+  private MockMvc mvc;
+  
+  @MockBean
+  private FakeSandboxRestService fakeSandboxMock;
+  
+  @Test
+  public void resultStatusFailedWhenTestTaskInSubmission() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    String url = "localhost";
+    
+    mvc.perform(post("/tasks.json")
+        .param("token", uuid.toString())
+        .param("notify", url))
+        .andExpect(status().isOk());
+    
+    verify(fakeSandboxMock).postSubmissionResults(eq(uuid.toString()), eq(url));
+  }
+}

--- a/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
+++ b/src/test/java/pingis/controllers/FakeSandboxControllerTest.java
@@ -1,27 +1,13 @@
 package pingis.controllers;
 
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.Matchers.eq;
-
-
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,11 +18,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import pingis.config.OAuthProperties;
 import pingis.config.SecurityConfig;
 import pingis.services.sandbox.FakeSandboxRestService;
-
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
  *

--- a/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
+++ b/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
@@ -1,51 +1,27 @@
 package pingis.services.sandbox;
 
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.mockito.Matchers.eq;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.client.MockRestServiceServer;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.context.WebApplicationContext;
-import pingis.config.SandboxSubmissionProperties;
-import pingis.config.SecurityConfig;
 import pingis.entities.Task;
 import pingis.entities.TaskInstance;
 import pingis.entities.TaskType;
@@ -53,17 +29,6 @@ import pingis.entities.User;
 import pingis.entities.sandbox.Submission;
 import pingis.entities.sandbox.SubmissionStatus;
 import pingis.repositories.sandbox.SubmissionRepository;
-import pingis.services.sandbox.SubmissionSenderService;
-import java.util.Optional;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import pingis.Application;
-import pingis.config.OAuthProperties;
 
 /**
  *

--- a/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
+++ b/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
@@ -39,21 +39,21 @@ import pingis.repositories.sandbox.SubmissionRepository;
 @ContextConfiguration(classes = {FakeSandboxRestService.class})
 @DirtiesContext
 public class FakeSandboxRestServiceTest {
-  
+
   @Autowired
   private FakeSandboxRestService fakeSandboxRestService;
-  
+
   @MockBean
   private SubmissionRepository submissionRepositoryMock;
-  
+
   @Autowired
   private MockRestServiceServer server;
-  
+
   private UUID uuid;
   private String uri;
   private User user;
   private Submission submission;
-  
+
   @Before
   public void setUp() {
     uuid = UUID.randomUUID();
@@ -63,31 +63,31 @@ public class FakeSandboxRestServiceTest {
     submission.setId(uuid);
     submission.setStatus(SubmissionStatus.PENDING);
   }
-  
+
   @Test
   public void resultStatusFailedWhenTestTaskInSubmission() {
     driveTaskTypeExpectationTest(TaskType.TEST, "TESTS_FAILED");
   }
-  
+
   @Test
   public void resultStatusPassedWhenImplementationTaskInSubmission() {
     driveTaskTypeExpectationTest(TaskType.IMPLEMENTATION, "PASSED");
   }
-  
+
   private void driveTaskTypeExpectationTest(TaskType givenTaskType, String expectedContent) {
     Task task = new Task(0, givenTaskType, user, "name", "desc", "codeStub", 0, 0);
     TaskInstance taskInstance = new TaskInstance(user, "code", task);
     submission.setTaskInstance(taskInstance);
-    
+
     when(submissionRepositoryMock.findById(eq(uuid)))
         .thenReturn(Optional.of(submission));
-        
+
     server.expect(requestTo(uri))
         .andExpect(method(HttpMethod.POST))
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
         .andExpect(content().string(containsString(expectedContent)))
         .andRespond(withSuccess());
-    
+
     fakeSandboxRestService.postSubmissionResults(uuid.toString(), uri);
   }
 }

--- a/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
+++ b/src/test/java/pingis/services/sandbox/FakeSandboxRestServiceTest.java
@@ -1,0 +1,128 @@
+package pingis.services.sandbox;
+
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Matchers.eq;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.client.MockRestServiceServer;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.WebApplicationContext;
+import pingis.config.SandboxSubmissionProperties;
+import pingis.config.SecurityConfig;
+import pingis.entities.Task;
+import pingis.entities.TaskInstance;
+import pingis.entities.TaskType;
+import pingis.entities.User;
+import pingis.entities.sandbox.Submission;
+import pingis.entities.sandbox.SubmissionStatus;
+import pingis.repositories.sandbox.SubmissionRepository;
+import pingis.services.sandbox.SubmissionSenderService;
+import java.util.Optional;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import pingis.Application;
+import pingis.config.OAuthProperties;
+
+/**
+ *
+ * @author juicyp
+ */
+@RunWith(SpringRunner.class)
+@RestClientTest(FakeSandboxRestService.class)
+@ContextConfiguration(classes = {FakeSandboxRestService.class})
+@DirtiesContext
+public class FakeSandboxRestServiceTest {
+  
+  @Autowired
+  private FakeSandboxRestService fakeSandboxRestService;
+  
+  @MockBean
+  private SubmissionRepository submissionRepositoryMock;
+  
+  @Autowired
+  private MockRestServiceServer server;
+  
+  private UUID uuid;
+  private String uri;
+  private User user;
+  private Submission submission;
+  
+  @Before
+  public void setUp() {
+    uuid = UUID.randomUUID();
+    uri = "/submission-result";
+    user = new User();
+    submission = new Submission();
+    submission.setId(uuid);
+    submission.setStatus(SubmissionStatus.PENDING);
+  }
+  
+  @Test
+  public void resultStatusFailedWhenTestTaskInSubmission() {
+    driveTaskTypeExpectationTest(TaskType.TEST, "TESTS_FAILED");
+  }
+  
+  @Test
+  public void resultStatusPassedWhenImplementationTaskInSubmission() {
+    driveTaskTypeExpectationTest(TaskType.IMPLEMENTATION, "PASSED");
+  }
+  
+  private void driveTaskTypeExpectationTest(TaskType givenTaskType, String expectedContent) {
+    Task task = new Task(0, givenTaskType, user, "name", "desc", "codeStub", 0, 0);
+    TaskInstance taskInstance = new TaskInstance(user, "code", task);
+    submission.setTaskInstance(taskInstance);
+    
+    when(submissionRepositoryMock.findById(eq(uuid)))
+        .thenReturn(Optional.of(submission));
+        
+    server.expect(requestTo(uri))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
+        .andExpect(content().string(containsString(expectedContent)))
+        .andRespond(withSuccess());
+    
+    fakeSandboxRestService.postSubmissionResults(uuid.toString(), uri);
+  }
+}


### PR DESCRIPTION
The POST request in the controller was separated into it's own FakeSandboxRestService-class to improve testability. Tests were written for the controller and the new REST service.
Also rename MockSubmissionPackagingService to SubmissionPackaginServiceStub because [mocks aren't stubs](https://martinfowler.com/articles/mocksArentStubs.html)(!).