### PR TITLE
JavaSyntaxChecker refactoring

### DIFF
--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -36,7 +36,6 @@ import pingis.services.sandbox.SandboxService;
 import pingis.utils.CodeStub;
 import pingis.utils.CodeStubBuilder;
 import pingis.utils.EditorTabData;
-import pingis.utils.JavaSyntaxChecker;
 import pingis.utils.TestStubBuilder;
 
 @Controller
@@ -88,9 +87,6 @@ public class TaskController {
     model.addAttribute("submissionTabFileName", isTest ? tab1.title : tab2.title);
     model.addAttribute("staticTabFileName", isTest ? tab2.title : tab1.title);
 
-    if (model.containsAttribute("code")) {
-      model.addAttribute("submissionCodeStub", model.asMap().get("code"));
-    }
     logger.info("entering editor view");
     return "task";
   }
@@ -100,12 +96,7 @@ public class TaskController {
       long taskInstanceId,
       RedirectAttributes redirectAttributes) throws IOException, ArchiveException {
     logger.info("submitting");
-    String[] errors = JavaSyntaxChecker.parseCode(submissionCode);
-    if (errors != null) {
-      redirectAttributes.addFlashAttribute("errors", errors);
-      redirectAttributes.addFlashAttribute("code", submissionCode);
-      return new RedirectView("/task/" + taskInstanceId);
-    }
+
     TaskInstance taskInstance = taskInstanceService.findOne(taskInstanceId);
     Challenge currentChallenge = taskInstance.getTask().getChallenge();
 

--- a/src/main/java/pingis/utils/JavaSyntaxChecker.java
+++ b/src/main/java/pingis/utils/JavaSyntaxChecker.java
@@ -10,33 +10,11 @@ import com.github.javaparser.ast.CompilationUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Helper class for checking the syntax of Java code. Created by dwarfcrank on 7/21/17.
  */
 public class JavaSyntaxChecker {
-
-  /**
-   * Parses the code to check its syntax.
-   *
-   * @param code Code to parse. Expects a whole Java compilation unit (i.e. package
-   * declarations/imports, class definitions, etc.).
-   * @return Array of strings describing the encountered parse errors, or null if the syntax is
-   * correct.
-   */
-  public static String[] parseCode(String code) {
-    ParseResult<CompilationUnit> parseResult = new JavaParser().parse(ParseStart.COMPILATION_UNIT,
-        Providers.provider(code));
-
-    if (parseResult.isSuccessful()) {
-      return null;
-    }
-
-    return parseResult.getProblems().stream().map((prob) ->
-        prob.getVerboseMessage()
-    ).toArray(String[]::new);
-  }
 
   private static SyntaxError convertProblem(Problem problem) {
     Position faultyToken = problem.getLocation().get().getBegin().getRange().begin;
@@ -60,15 +38,5 @@ public class JavaSyntaxChecker {
     return Optional.of(parseResult.getProblems().stream()
         .map(JavaSyntaxChecker::convertProblem)
         .collect(Collectors.toList()));
-  }
-
-  public static String[] checkTaskPairErrors(String submissionCode, String staticCode) {
-    String[] submissionSyntaxErrors = parseCode(submissionCode);
-    String[] staticSyntaxErrors = parseCode(staticCode);
-    if (submissionSyntaxErrors != null || staticSyntaxErrors != null) {
-      String[] errors = ArrayUtils.addAll(submissionSyntaxErrors, staticSyntaxErrors);
-      return errors;
-    }
-    return null;
   }
 }


### PR DESCRIPTION
* Remove `parseCode` and `checkTaskPairErrors`.
* Remove use of `JavaSyntaxChecker` in `TaskController`, as failed syntax checks disable the submit button and the sandbox will reject forceful submissions anyway.