### PR TITLE
support for completed challenges added + fixes to ui

### DIFF
--- a/src/main/java/pingis/controllers/ChallengeController.java
+++ b/src/main/java/pingis/controllers/ChallengeController.java
@@ -325,7 +325,12 @@ public class ChallengeController {
 
     Task nextTask = taskService.nextPracticeTask(challenge);
     if (nextTask == null) {
-      // User has completed the practice challenge. TODO: Award points?
+      // User has completed the practice challenge.
+      challenge.addNewCompletedPlayer(player);
+      player.addCompletedChallenge(challenge);
+      challengeService.save(challenge);
+      userService.save(player);
+      
       logger.debug("All tasks done");
       return new RedirectView("/challengeFinished/" + challenge.getId());
     }

--- a/src/main/java/pingis/controllers/ChallengeController.java
+++ b/src/main/java/pingis/controllers/ChallengeController.java
@@ -330,7 +330,7 @@ public class ChallengeController {
       player.addCompletedChallenge(challenge);
       challengeService.save(challenge);
       userService.save(player);
-      
+
       logger.debug("All tasks done");
       return new RedirectView("/challengeFinished/" + challenge.getId());
     }

--- a/src/main/java/pingis/controllers/UserController.java
+++ b/src/main/java/pingis/controllers/UserController.java
@@ -53,20 +53,21 @@ public class UserController {
     User user = userService.handleUserAuthenticationByName(principal.getName());
     model.addAttribute("userLevel", userService.levelOfCurrentUser());
     model.addAttribute("user", user);
-
+    
     MultiValueMap<Challenge, TaskInstance> myTasksInChallenges
-                                          = challengeService.getCompletedTaskInstancesByChallenge();
-    TaskInstance       lastUnfinished     = taskInstanceService.getLastUnfinishedInstance();
-    List<TaskInstance> history            = taskInstanceService.getHistory();
-    List<Challenge>   availableChallenges = challengeService.getAvailableChallenges(
-                                                                 myTasksInChallenges);
-
+            = challengeService.getCompletedTaskInstancesInUnfinishedChallenges();
+    TaskInstance lastUnfinished = taskInstanceService.getLastUnfinishedInstance();
+    List<TaskInstance> history = taskInstanceService.getHistory();
+    List<Challenge> availableChallenges = challengeService.getAvailableChallenges(
+            myTasksInChallenges);
+    
     model.addAttribute("myTasksInChallenges", myTasksInChallenges);
     model.addAttribute("unfinishedTaskInstance", lastUnfinished);
     model.addAttribute("history", history);
     model.addAttribute("availableChallenges", availableChallenges);
-
-    logger.info("Found " + history.size() + " done task-instances.");
+    
+    logger.info("Found " + history.size() + " completed task-instances.");
+    logger.info("Found " + user.getCompletedChallenges().size() + " completed challenges.");
     if (lastUnfinished != null) {
       logger.info("Found latest unfinished taskinstance of task "
                             + lastUnfinished.getTask().getName());

--- a/src/main/java/pingis/controllers/UserController.java
+++ b/src/main/java/pingis/controllers/UserController.java
@@ -53,19 +53,19 @@ public class UserController {
     User user = userService.handleUserAuthenticationByName(principal.getName());
     model.addAttribute("userLevel", userService.levelOfCurrentUser());
     model.addAttribute("user", user);
-    
+
     MultiValueMap<Challenge, TaskInstance> myTasksInChallenges
             = challengeService.getCompletedTaskInstancesInUnfinishedChallenges();
     TaskInstance lastUnfinished = taskInstanceService.getLastUnfinishedInstance();
     List<TaskInstance> history = taskInstanceService.getHistory();
     List<Challenge> availableChallenges = challengeService.getAvailableChallenges(
             myTasksInChallenges);
-    
+
     model.addAttribute("myTasksInChallenges", myTasksInChallenges);
     model.addAttribute("unfinishedTaskInstance", lastUnfinished);
     model.addAttribute("history", history);
     model.addAttribute("availableChallenges", availableChallenges);
-    
+
     logger.info("Found " + history.size() + " completed task-instances.");
     logger.info("Found " + user.getCompletedChallenges().size() + " completed challenges.");
     if (lastUnfinished != null) {

--- a/src/main/java/pingis/entities/Challenge.java
+++ b/src/main/java/pingis/entities/Challenge.java
@@ -55,7 +55,7 @@ public class Challenge {
 
   @ManyToMany(mappedBy = "completedChallenges")
   private List<User> completedByPlayers;
-  
+
   public User getSecondPlayer() {
     return secondPlayer;
   }
@@ -192,7 +192,7 @@ public class Challenge {
   public void setRealm(Realm realm) {
     this.realm = realm;
   }
-  
+
   public void addNewCompletedPlayer(User user) {
     if (!this.completedByPlayers.contains(user)) {
       this.completedByPlayers.add(user);

--- a/src/main/java/pingis/entities/Challenge.java
+++ b/src/main/java/pingis/entities/Challenge.java
@@ -14,6 +14,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.Max;
@@ -52,6 +53,9 @@ public class Challenge {
   @ManyToOne(fetch = FetchType.EAGER)
   private User author;
 
+  @ManyToMany(mappedBy = "completedChallenges")
+  private List<User> completedByPlayers;
+  
   public User getSecondPlayer() {
     return secondPlayer;
   }
@@ -81,6 +85,7 @@ public class Challenge {
     this.description = description;
     this.type = type;
     this.tasks = new ArrayList<>();
+    this.completedByPlayers = new ArrayList<>();
     this.isOpen = false;
     this.level = 0;
   }
@@ -186,6 +191,12 @@ public class Challenge {
 
   public void setRealm(Realm realm) {
     this.realm = realm;
+  }
+  
+  public void addNewCompletedPlayer(User user) {
+    if (!this.completedByPlayers.contains(user)) {
+      this.completedByPlayers.add(user);
+    }
   }
 
 }

--- a/src/main/java/pingis/entities/User.java
+++ b/src/main/java/pingis/entities/User.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -40,6 +42,10 @@ public class User {
 
   @OneToMany(mappedBy = "secondPlayer")
   private List<Challenge> participatingLiveChallenges;
+  
+  @ManyToMany
+  @JoinTable
+  private List<Challenge> completedChallenges;
 
   public User() {
   }
@@ -62,6 +68,7 @@ public class User {
     this.taskInstances = new ArrayList<>();
     this.authoredChallenges = new ArrayList<>();
     this.authoredTasks = new ArrayList<>();
+    this.completedChallenges = new ArrayList<>();
     this.participatingLiveChallenges = new ArrayList<>();
   }
 
@@ -181,6 +188,20 @@ public class User {
 
   public void addParticipatingLiveChallenge(Challenge challenge) {
     this.participatingLiveChallenges.add(challenge);
+  }
+  
+  public void addCompletedChallenge(Challenge challenge) {
+    if (!this.completedChallenges.contains(challenge)) {
+      this.completedChallenges.add(challenge);
+    }
+  }
+  
+  public List<Challenge> getCompletedChallenges() {
+    return completedChallenges;
+  }
+
+  public void setCompletedChallenges(List<Challenge> completedChallenges) {
+    this.completedChallenges = completedChallenges;
   }
 
 }

--- a/src/main/java/pingis/entities/User.java
+++ b/src/main/java/pingis/entities/User.java
@@ -42,7 +42,7 @@ public class User {
 
   @OneToMany(mappedBy = "secondPlayer")
   private List<Challenge> participatingLiveChallenges;
-  
+
   @ManyToMany
   @JoinTable
   private List<Challenge> completedChallenges;
@@ -189,13 +189,13 @@ public class User {
   public void addParticipatingLiveChallenge(Challenge challenge) {
     this.participatingLiveChallenges.add(challenge);
   }
-  
+
   public void addCompletedChallenge(Challenge challenge) {
     if (!this.completedChallenges.contains(challenge)) {
       this.completedChallenges.add(challenge);
     }
   }
-  
+
   public List<Challenge> getCompletedChallenges() {
     return completedChallenges;
   }

--- a/src/main/java/pingis/services/ChallengeService.java
+++ b/src/main/java/pingis/services/ChallengeService.java
@@ -104,13 +104,17 @@ public class ChallengeService {
 
     return availableChallenges;
   }
-
-  public MultiValueMap<Challenge, TaskInstance> getCompletedTaskInstancesByChallenge() {
+  
+  public MultiValueMap<Challenge, TaskInstance> getCompletedTaskInstancesInUnfinishedChallenges() {
     MultiValueMap<Challenge, TaskInstance> myTasksInChallenges = new LinkedMultiValueMap<>();
     userService.getCurrentUser().getTaskInstances().stream()
             .filter(e -> !e.getChallenge().getIsOpen())
             .filter(e -> e.getStatus().equals(CodeStatus.DONE))
             .forEach(e -> myTasksInChallenges.add(e.getChallenge(), e));
+    
+    myTasksInChallenges.keySet().stream()
+            .filter(e -> userService.getCurrentUser().getCompletedChallenges().contains(e))
+            .forEach(e -> myTasksInChallenges.remove(e));
 
     return myTasksInChallenges;
   }

--- a/src/main/java/pingis/services/ChallengeService.java
+++ b/src/main/java/pingis/services/ChallengeService.java
@@ -104,14 +104,14 @@ public class ChallengeService {
 
     return availableChallenges;
   }
-  
+
   public MultiValueMap<Challenge, TaskInstance> getCompletedTaskInstancesInUnfinishedChallenges() {
     MultiValueMap<Challenge, TaskInstance> myTasksInChallenges = new LinkedMultiValueMap<>();
     userService.getCurrentUser().getTaskInstances().stream()
             .filter(e -> !e.getChallenge().getIsOpen())
             .filter(e -> e.getStatus().equals(CodeStatus.DONE))
             .forEach(e -> myTasksInChallenges.add(e.getChallenge(), e));
-    
+
     myTasksInChallenges.keySet().stream()
             .filter(e -> userService.getCurrentUser().getCompletedChallenges().contains(e))
             .forEach(e -> myTasksInChallenges.remove(e));

--- a/src/main/resources/static/css/site.css
+++ b/src/main/resources/static/css/site.css
@@ -317,7 +317,7 @@ textarea {
 }
 
 .task-container {
-  width: 65vw;
+  width: 61vw;
 }
 
 .task-history-item {
@@ -339,13 +339,22 @@ textarea {
 }
 
 .task-topmost-div {
+  padding-bottom: 2vw;
   background: linear-gradient(-30deg, #2AC3EB, #005EAE);
 }
 
 .task-topbar-challenge-info {
   height: fit-content;
   margin-left: 20%;
+  padding-top: 3vw;
   margin-right: 20%;
+}
+
+.taskview-challenge-heading {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  display: inline;
 }
 
 .tooltip {

--- a/src/main/resources/templates/task.html
+++ b/src/main/resources/templates/task.html
@@ -7,11 +7,10 @@
       <nav th:include="navbar :: navigation"></nav>
       <div class="divider task-topmost-div" >
          <div class="row task-topbar-challenge-info" th:unless="${task.challenge.type == T(pingis.entities.ChallengeType).ARCADE}"> <!-- top bar -->
-            <h1>Challenge: </h1><h2 id="challenge-name" th:inline="text"> [[${challenge.name}]]</h2>
-            <p th:inline="text" class="lead dashboard-user-name"><strong>Task number: 5/12</strong></p>
-            <p class="lead dashboard-user-name"><strong>Rank: </strong></p>  <!-- TODO: support for different ranks -->
+            <h2 class="taskview-challenge-heading">Challenge: </h2><h1 th:inline="text">&nbsp; [[${challenge.name}]]</h1>
+            <br><p th:inline="text" class="lead dashboard-user-name taskview-challenge-heading"><strong>Task number:</strong> &nbsp;&nbsp;&nbsp;[[${task.index}]] / [[${#lists.size(task.challenge.tasks)}]]</p>
          </div>
-         <div class="row task-topbar-challenge-info" th:if="${task.challenge.type == T(pingis.entities.ChallengeType).ARCADE}">
+         <div class="row task-topbar-challenge-info" th:if="${task.challenge.type == T(pingis.entities.ChallengeType).ARCADE}">  
             <h1>Arcade challenge </h1><h2 th:inline="text">[[${challenge.realm}]]</h2>
             <p class="lead dashboard-user-name"><strong>Rank: </strong>Super Guru!</p>
          </div>
@@ -20,8 +19,11 @@
       <div class="container task-container">
          <div class="row">
             <div class="col-md-4">
-               <p id="task-name" th:inline="text">Task: [[${task.name}]]</p>
-               <p th:inline="text">Level: [[${task.level}]]</p>
+               <p th:inline="text">Task: &nbsp;<strong>[[${task.name}]]</strong></p>
+               <p th:if="${task.type == T(pingis.entities.TaskType).TEST}">Task type: &nbsp;<strong> Test</strong></p>
+               <p th:if="${task.type == T(pingis.entities.TaskType).IMPLEMENTATION}">Task type: &nbsp;<strong>Implementation</strong></p>
+               <p th:inline="text">Points available: &nbsp;<strong>[[${task.points}]]</strong></p>
+               <p th:inline="text">Level: &nbsp;<strong>[[${task.level}]]</strong></p>
             </div>
             <div class="col-md-6">
                <p id="task-desc" th:text="${task.desc}"></p><br/><br/>

--- a/src/main/resources/templates/task.html
+++ b/src/main/resources/templates/task.html
@@ -7,7 +7,7 @@
       <nav th:include="navbar :: navigation"></nav>
       <div class="divider task-topmost-div" >
          <div class="row task-topbar-challenge-info" th:unless="${task.challenge.type == T(pingis.entities.ChallengeType).ARCADE}"> <!-- top bar -->
-            <h2 class="taskview-challenge-heading">Challenge: </h2><h1 th:inline="text">&nbsp; [[${challenge.name}]]</h1>
+             <h2 class="taskview-challenge-heading">Challenge: </h2><h1 id="challenge-name" th:inline="text">&nbsp; [[${challenge.name}]]</h1>
             <br><p th:inline="text" class="lead dashboard-user-name taskview-challenge-heading"><strong>Task number:</strong> &nbsp;&nbsp;&nbsp;[[${task.index}]] / [[${#lists.size(task.challenge.tasks)}]]</p>
          </div>
          <div class="row task-topbar-challenge-info" th:if="${task.challenge.type == T(pingis.entities.ChallengeType).ARCADE}">  
@@ -19,7 +19,7 @@
       <div class="container task-container">
          <div class="row">
             <div class="col-md-4">
-               <p th:inline="text">Task: &nbsp;<strong>[[${task.name}]]</strong></p>
+               <p id="task-name" th:inline="text">Task: &nbsp;<strong>[[${task.name}]]</strong></p>
                <p th:if="${task.type == T(pingis.entities.TaskType).TEST}">Task type: &nbsp;<strong> Test</strong></p>
                <p th:if="${task.type == T(pingis.entities.TaskType).IMPLEMENTATION}">Task type: &nbsp;<strong>Implementation</strong></p>
                <p th:inline="text">Points available: &nbsp;<strong>[[${task.points}]]</strong></p>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -19,7 +19,7 @@
                   </div>
                </div>
                <div class="col-md-5">
-                  <h4 th:inline="text" class="header dashboardtopbar-stats">Challenges completed: [[${userLevel}]]</h4>
+                  <h4 th:inline="text" class="header dashboardtopbar-stats">Challenges completed: [[${#lists.size(user.completedChallenges)}]]</h4>
                </div>
                <div class="col-md-3">
                   <h4 th:inline="text" class="header dashboardtopbar-stats">Level: [[${userLevel}]]</h4>
@@ -45,13 +45,12 @@
             <div th:if="${message != null}" th:text="${message}"></div> <!-- still needed? there is new error box which supports multiple error-messages -->
             <div class="challenge_list row">
                <div class="col-md-6">
-                  <div th:unless="${unfinishedTaskinstance == null}" class="divider">
+                  <div th:unless="${unfinishedTaskInstance == null}" class="divider">
                      <h3 class="header challenge-col-header">Continue</h3>
                      <div class="well challenge-col-well">You have one Task still in progress. Continue where you left off.</div>
-                     <div th:unless="${unfinishedTaskinstance == null}" class="row challengeitem">
-                        <a th:href="'/nextTask/' + ${unfinishedTaskinstance.task.challenge.id}" th:inline="text"><h3 class="header challengeitem-header">[[${unfinishedTaskinstance.task.challenge.id}]]</h3></a>
-                        <p class="lead challenge-progress-number" th:inline="text">[[${#lists.size(unfinishedTaskinstance.task.challenge.tasks)}]] / [[${#lists.size(unfinishedTaskinstance.task.challenge.tasks)} / 2]]</p>
-                        <p class="challenge-progress-done">done</p>
+                     <div class="row challengeitem">
+                        <a th:href="'/playChallenge/' + ${unfinishedTaskInstance.task.challenge.id}" th:inline="text"><h3 class="header challengeitem-header">[[${unfinishedTaskInstance.task.challenge.name}]]</h3></a>
+                        <p class="lead challenge-progress-done" th:inline="text"><strong>Task:&nbsp;</strong> [[${unfinishedTaskInstance.task.name}]]</p>
                      </div>
                   </div>
 
@@ -115,11 +114,12 @@
             <div class="col-md-6">
                <h3 class="header challenge-col-header">Started challenges</h3>
                <div th:if="${#maps.isEmpty(myTasksInChallenges)}" class="well challenge-col-well">No ongoing challenges</div>
+               <div th:unless="${#maps.isEmpty(myTasksInChallenges)}" class="well challenge-col-well">You have not completed all of your challenges yet.</div>
                <div th:each="challenge : ${myTasksInChallenges}">
                   <a th:href="'/playChallenge/' + ${challenge.key.id}" th:inline="text">
                      <div class="row challengeitem">
                         <h3 class="header challengeitem-header">[[${challenge.key.name}]]</h3>
-                        <p class="lead challenge-progress-done" th:inline="text">[[${#lists.size(challenge.value)}]] / [[${#lists.size(challenge.key.tasks) / 2}]] &nbsp;<strong>done</strong></p>
+                        <p class="lead challenge-progress-done" th:inline="text">[[${#lists.size(challenge.value)}]] / [[${#lists.size(challenge.key.tasks)}]] &nbsp;<strong>done</strong></p>
                      </div>
                   </a>
                </div>
@@ -128,18 +128,17 @@
                <p>Here you can select a challenge and practice by doing tasks at your own pace.</p>
                <hr>
                <div class="header challenge-col-header">Available challenges</div>
-               <div class="well challenge-col-well">New practice challenges are available.</div>
-               <div th:if="${availableChallenges.empty}">No open challenges</div>
+               <div th:unless="${availableChallenges.empty}" class="well challenge-col-well">New practice challenges are available.</div>
+               <div th:if="${availableChallenges.empty}" class="well challenge-col-well">No open challenges</div>
                <div th:each="challenge : ${availableChallenges}" class="row challengeitem">
-                  <a th:href="'/startChallenge/' + ${challenge.id}" th:id="'open-challenge-'+${challenge.name}" ><h3 class="header challengeitem-header" th:inline="text">[[${challenge.name}]]</h3></a> <p th:inline="text" class="lead challenge-progress-done">Not started </p>
+                  <a th:href="'/startChallenge/' + ${challenge.id}" th:id="'open-challenge-'+${challenge.name}" ><h3 class="header challengeitem-header" th:inline="text">[[${challenge.name}]]</h3></a> <p th:inline="text" class="lead challenge-progress-done">Not started</p>
                </div>
             </div>
           </div>
          </div>
 
          <div id="history-tab" class="tab-pane fade">
-
-            <div th:if="${history.empty}" class="well history-col-well">None yet. Go on and <strong>play a little!</strong></div>
+            <div th:if="${history.empty}" class="well history-col-well">Your history is empty.</div>
             <div th:unless="${history.empty}" class="well history-col-well">Your tasks, from the most recent to the oldest.</div>
             <div th:each="taskInst : ${history}" class="div task-history-item">
                <p th:inline="text" class="history-header"><strong>Task:</strong> [[${taskInst.task.name}]]</p>


### PR DESCRIPTION
* Fix leftover static placeholders in UI
* Fix filtering of completed challenges 
from "started challenges"-list in the dashboard
* Add support for completed challenges to `User` and `Challenge`
* Fix the continue-functionality in dashboard 
* __Go Home__, get rid of Muda