### PR TITLE
Modified the logging configuration

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -29,8 +29,3 @@ security:
 tmc:
   sandboxUrl: http://localhost:8080
   notifyUrl: http://localhost:8080/submission-result
-
-logging:
-  level:
-    ROOT: INFO
-    pingis: DEBUG

--- a/gradle/helpers/test-config.gradle
+++ b/gradle/helpers/test-config.gradle
@@ -2,6 +2,7 @@ apply from: 'gradle/helpers/test-printing.gradle'
 
 tasks.withType(Test).all {
     systemProperty "spring.profiles.active", "dev"
+    testLogging.showStandardStreams = true
 }
 
 task unit (type: Test) {
@@ -18,8 +19,6 @@ task cucumber (type: Test) {
     //systemProperty "cucumber.options", "--tags @debug"
 }
 
-test.testLogging.showStandardStreams = true
-
 // If not running in Travis, we want to use the unit task instead of test
 if (System.env.TRAVIS != 'true') {
     test { exclude '**' }
@@ -29,12 +28,6 @@ if (System.env.TRAVIS != 'true') {
 // For running all tests during build
 if(System.env.TESTS == 'ALL') {
   test.dependsOn cucumber
-}
-
-// For running tests with stdout
-if(System.env.STDOUT == 'ON') {
-    unit.testLogging.showStandardStreams = true
-    cucumber.testLogging.showStandardStreams = true
 }
 
 cucumber.mustRunAfter unit

--- a/gradle/helpers/test-config.gradle
+++ b/gradle/helpers/test-config.gradle
@@ -2,7 +2,7 @@ apply from: 'gradle/helpers/test-printing.gradle'
 
 tasks.withType(Test).all {
     systemProperty "spring.profiles.active", "dev"
-    testLogging.showStandardStreams = true
+    testLogging.events = ['standard_out', 'standard_error']
 }
 
 task unit (type: Test) {
@@ -13,6 +13,7 @@ task unit (type: Test) {
 task cucumber (type: Test) {
     testLogging { afterSuite { desc, result -> printTestResults(desc,result,'CUKE') } }
     include '**/cucumber/**'
+    testLogging.events = ['standard_out']
 
     // Use for debugging specific Cucumber tests
     // Add the @debug tag above a feature or scenario you want to test

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="pingis" level="DEBUG"/>
+
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="pingis" level="DEBUG"/>
+
+</configuration>


### PR DESCRIPTION
Moved the logging config from application.yml to logback.xml and logback-test.xml for separate configuration for testing. Stdout is now on by default for tests as there's much less noise thanks to root being set to error.

As a result it's now reasonable to use loggers in test classes, with all the other prints it will hopeful make for easier debugging. Travis logs should be siginificantly more readable as well.