### PR TITLE
Correct filenames

### DIFF
--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -99,7 +99,7 @@ public class TaskController {
     TaskInstance taskInstance = taskInstanceService.findOne(taskInstanceId);
     Challenge currentChallenge = taskInstance.getTask().getChallenge();
 
-    Submission submission = submitToTmc(taskInstance, currentChallenge, submissionCode);
+    Submission submission = submitToTmc(taskInstance, submissionCode);
 
     redirectAttributes.addFlashAttribute("submissionId", submission.getId().toString());
     redirectAttributes.addFlashAttribute("taskInstance", taskInstance);
@@ -133,8 +133,7 @@ public class TaskController {
     return "OK";
   }
 
-  private Submission submitToTmc(TaskInstance taskInstance, Challenge challenge,
-      String submissionCode)
+  private Submission submitToTmc(TaskInstance taskInstance, String submissionCode)
       throws IOException, ArchiveException {
     logger.debug("Submitting to TMC");
     Map<String, byte[]> files = new HashMap<>();

--- a/src/main/java/pingis/controllers/TaskController.java
+++ b/src/main/java/pingis/controllers/TaskController.java
@@ -103,7 +103,7 @@ public class TaskController {
 
     redirectAttributes.addFlashAttribute("submissionId", submission.getId().toString());
     redirectAttributes.addFlashAttribute("taskInstance", taskInstance);
-    redirectAttributes.addFlashAttribute("challenge", currentChallenge);
+    redirectAttributes.addFlashAttribute("challengeId", currentChallenge.getId());
     redirectAttributes.addFlashAttribute("user", userService.getCurrentUser());
 
     // Save user's answer from left editor
@@ -139,7 +139,7 @@ public class TaskController {
     logger.debug("Submitting to TMC");
     Map<String, byte[]> files = new HashMap<>();
 
-    CodeStubBuilder stubBuilder = new CodeStubBuilder(challenge.getName());
+    CodeStubBuilder stubBuilder = CodeStubBuilder.fromCode(submissionCode);
     CodeStub implStub = stubBuilder.build();
     CodeStub testStub = new TestStubBuilder(stubBuilder).build();
 

--- a/src/main/resources/templates/feedback.html
+++ b/src/main/resources/templates/feedback.html
@@ -20,7 +20,7 @@
             <div class="row">
                 <div class="col-md-6">
                     <a id="back-button" th:href="'task/'+${taskInstance.id}" class="btn btn-primary">Back</a>
-                    <a th:href="'playChallenge/'+${challenge.id}" id="next-task-button" class="nexttask btn btn-success">Next task</a>
+                    <a th:href="'playChallenge/'+${challengeId}" id="next-task-button" class="nexttask btn btn-success">Next task</a>
                     <a href="/user" id="selectFromList" class="nexttask btn btn-success">Back to dashboard</a>
                 </div>
             </div>

--- a/src/test/java/pingis/controllers/TaskControllerTest.java
+++ b/src/test/java/pingis/controllers/TaskControllerTest.java
@@ -95,13 +95,13 @@ public class TaskControllerTest {
         "Simple calculator");
     testTask = new Task(1,
         TaskType.TEST, testUser, "CalculatorAddition",
-        "Implement addition", "return 1+1;", 1, 1);
+        "Implement addition", "public class Test {}", 1, 1);
     implementationTask = new Task(2,
         TaskType.IMPLEMENTATION, testUser, "implement addition",
-        "implement addition", "public test", 1, 1);
+        "implement addition", "public class Impl {}", 1, 1);
     testTaskInstance
-        = new TaskInstance(testUser, "", testTask);
-    implTaskInstance = new TaskInstance(testUser, "",
+        = new TaskInstance(testUser, "public class Test {}", testTask);
+    implTaskInstance = new TaskInstance(testUser, "public class Impl {}",
         implementationTask);
     implTaskInstance.setTestTaskInstance(testTaskInstance);
     testTask.setChallenge(challenge);
@@ -169,7 +169,7 @@ public class TaskControllerTest {
 
   @Test
   public void submitTestTask() throws Exception {
-    String submissionCode = "/* this is a test */";
+    String submissionCode = "public class Task {}";
 
     when(taskInstanceServiceMock.findOne(testTaskInstance.getId())).thenReturn(testTaskInstance);
     when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);
@@ -194,7 +194,7 @@ public class TaskControllerTest {
 
   @Test
   public void submitImplementationTask() throws Exception {
-    String submissionCode = "/* this is an implementation */";
+    String submissionCode = "public class Impl {}";
 
     when(taskInstanceServiceMock.findOne(implTaskInstance.getId())).thenReturn(implTaskInstance);
     when(challengeServiceMock.findOne(challenge.getId())).thenReturn(challenge);

--- a/src/test/java/pingis/cucumber/pages/TaskPage.java
+++ b/src/test/java/pingis/cucumber/pages/TaskPage.java
@@ -16,7 +16,7 @@ public class TaskPage extends NavbarPage {
   public void addCode(String code) {
     String existingCode =
             (String) driver.executeScript("return submissionEditor.getValue();");
-    driver.executeScript("submissionEditor.setValue(`" + existingCode + " " + code + "`);");
+    driver.executeScript("submissionEditor.setValue(`" + existingCode + " //" + code + "`);");
   }
 
   public boolean activeEditorContains(String content) {


### PR DESCRIPTION
Made it so the filenames included in a submission are correct. The Selenium tests now add commented code as the submissions pass through JavaParser. The changes to other tests were done for the same reason.

Since only the challenge id was used in feedback I also changed it so only the id is included in the redirectAttributes. It also fixed an issue with the challenge not being initialized properly due to lazy fetching from the database.